### PR TITLE
Requirement is now default constructable

### DIFF
--- a/src/RepoAuditor/Requirement.py
+++ b/src/RepoAuditor/Requirement.py
@@ -26,7 +26,6 @@ class EvaluateResult(Enum):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class Requirement(ABC):
     """A single requirement that can be evaluated against a set of data."""
 
@@ -49,20 +48,24 @@ class Requirement(ABC):
 
     # ----------------------------------------------------------------------
     # |
-    # |  Public Data
-    # |
-    # ----------------------------------------------------------------------
-    name: str
-    description: str
-    style: ExecutionStyle
-
-    resolution_template: str
-    rationale_template: str
-
-    # ----------------------------------------------------------------------
-    # |
     # |  Public Methods
     # |
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        style: ExecutionStyle,
+        resolution_template: str,
+        rationale_template: str,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.style = style
+
+        self.resolution_template = resolution_template
+        self.rationale_template = rationale_template
+
     # ----------------------------------------------------------------------
     def Evaluate(
         self,

--- a/tests/Executor_UnitTest.py
+++ b/tests/Executor_UnitTest.py
@@ -41,9 +41,21 @@ class MyQuery(Query):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyRequirement(Requirement):
-    result: EvaluateResult
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        style: ExecutionStyle,
+        resolution_template: str,
+        rationale_template: str,
+        result: EvaluateResult,
+    ) -> None:
+        super(MyRequirement, self).__init__(
+            name, description, style, resolution_template, rationale_template
+        )
+        self.result = result
 
     # ----------------------------------------------------------------------
     # ----------------------------------------------------------------------

--- a/tests/Module_UnitTest.py
+++ b/tests/Module_UnitTest.py
@@ -52,9 +52,21 @@ class MyQuery(Query):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyRequirement(Requirement):
-    evaluate_result: EvaluateResult
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        style: ExecutionStyle,
+        resolution_template: str,
+        rationale_template: str,
+        evaluate_result: EvaluateResult,
+    ) -> None:
+        super(MyRequirement, self).__init__(
+            name, description, style, resolution_template, rationale_template
+        )
+        self.evaluate_result = evaluate_result
 
     # ----------------------------------------------------------------------
     # ----------------------------------------------------------------------

--- a/tests/Query_UnitTest.py
+++ b/tests/Query_UnitTest.py
@@ -51,10 +51,24 @@ class MyQuery(Query):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyRequirement(Requirement):
-    expected_result: EvaluateResult
-    context: Optional[str] = field(default=None)
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        style: ExecutionStyle,
+        resolution_template: str,
+        rationale_template: str,
+        expected_result: EvaluateResult,
+        context: Optional[str] = None,
+    ) -> None:
+        super(MyRequirement, self).__init__(
+            name, description, style, resolution_template, rationale_template
+        )
+
+        self.expected_result = expected_result
+        self.context = context
 
     # ----------------------------------------------------------------------
     # ----------------------------------------------------------------------

--- a/tests/Requirement_UnitTest.py
+++ b/tests/Requirement_UnitTest.py
@@ -6,7 +6,6 @@
 # -------------------------------------------------------------------------------
 """Unit tests for Requirement.py"""
 
-from dataclasses import dataclass, field
 from unittest.mock import Mock
 
 from dbrownell_Common.Types import override
@@ -15,10 +14,24 @@ from RepoAuditor.Requirement import *
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyRequirement(Requirement):
-    expected_result: EvaluateResult
-    context: Optional[str] = field(default=None)
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        style: ExecutionStyle,
+        resolution_template: str,
+        rationale_template: str,
+        expected_result: EvaluateResult,
+        context: Optional[str] = None,
+    ) -> None:
+        super(MyRequirement, self).__init__(
+            name, description, style, resolution_template, rationale_template
+        )
+
+        self.expected_result = expected_result
+        self.context = context
 
     # ----------------------------------------------------------------------
     # ----------------------------------------------------------------------


### PR DESCRIPTION
This is commit 1 of N to make RepoAuditor classes default constructable for easier command line processing.

Once these changes are complete, command line arguments will be passed to the modules as dictionaries rather than provided to modules as constructor arguments. This large set of changes is broken into smaller changes to make them easier to review.