### PR TITLE
Query is now default constructable

### DIFF
--- a/src/RepoAuditor/Query.py
+++ b/src/RepoAuditor/Query.py
@@ -29,7 +29,6 @@ class OnStatusFunc(Protocol):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class Query(ABC):
     """A collection of Requirements that operate on a consistent set of data."""
 
@@ -46,19 +45,19 @@ class Query(ABC):
 
     # ----------------------------------------------------------------------
     # |
-    # |  Public Data
-    # |
-    # ----------------------------------------------------------------------
-    name: str
-    description: str
-    style: ExecutionStyle
-
-    requirements: list[Requirement]
-
-    # ----------------------------------------------------------------------
-    # |
     # |  Public Methods
     # |
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        style: ExecutionStyle,
+        requirements: list[Requirement],
+    ) -> None:
+        self.name = name
+        self.style = style
+        self.requirements = requirements
+
     # ----------------------------------------------------------------------
     @abstractmethod
     def GetData(

--- a/tests/Executor_UnitTest.py
+++ b/tests/Executor_UnitTest.py
@@ -29,7 +29,6 @@ class MyModule(Module):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyQuery(Query):
     @override
     def GetData(
@@ -103,7 +102,6 @@ def test_Successful(single_threaded):
             queries.append(
                 MyQuery(
                     f"Query-{module_index}-{query_index}",
-                    "",
                     GetExecutionStyle(query_index),
                     requirements,
                 ),
@@ -170,7 +168,6 @@ def test_NotSuccess(data):
             queries.append(
                 MyQuery(
                     f"Query-{module_index}-{query_index}",
-                    "",
                     GetExecutionStyle(query_index),
                     requirements,
                 ),

--- a/tests/Module_UnitTest.py
+++ b/tests/Module_UnitTest.py
@@ -34,9 +34,19 @@ class MyModule(Module):
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyQuery(Query):
-    produce_data: bool = field(kw_only=True)
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str,
+        style: ExecutionStyle,
+        requirements: list[Requirement],
+        *,
+        produce_data: bool,
+    ) -> None:
+        super(MyQuery, self).__init__(name, style, requirements)
+
+        self.produce_data = produce_data
 
     # ----------------------------------------------------------------------
     @override
@@ -48,6 +58,7 @@ class MyQuery(Query):
             return None
 
         module_data["query_data"] = self.name
+
         return module_data
 
 
@@ -171,7 +182,6 @@ requirementB4 = MyRequirement(
 
 queryA = MyQuery(
     "QueryA",
-    "The first query",
     ExecutionStyle.Parallel,
     [requirementA1, requirementA2, requirementA3, requirementA4],
     produce_data=True,
@@ -179,7 +189,6 @@ queryA = MyQuery(
 
 queryB = MyQuery(
     "QueryB",
-    "The second query",
     ExecutionStyle.Parallel,
     [requirementB1, requirementB2, requirementB3, requirementB4],
     produce_data=True,
@@ -187,7 +196,6 @@ queryB = MyQuery(
 
 queryC = MyQuery(
     "QueryC",
-    "The third query",
     ExecutionStyle.Sequential,
     [requirementA1, requirementA2, requirementA3],
     produce_data=False,

--- a/tests/Query_UnitTest.py
+++ b/tests/Query_UnitTest.py
@@ -6,7 +6,6 @@
 # -------------------------------------------------------------------------------
 """Unit test for Query.py"""
 
-from dataclasses import dataclass, field
 from unittest.mock import Mock
 
 import pytest
@@ -38,8 +37,8 @@ def test_StatusInfo():
 
 
 # ----------------------------------------------------------------------
-@dataclass(frozen=True)
 class MyQuery(Query):
+    # ----------------------------------------------------------------------
     @override
     def GetData(
         self,
@@ -134,7 +133,6 @@ requirement5 = MyRequirement(
 
 my_query = MyQuery(
     "MyQuery",
-    "This is my query.",
     ExecutionStyle.Sequential,
     [
         requirement1,
@@ -149,7 +147,6 @@ my_query = MyQuery(
 # ----------------------------------------------------------------------`
 def test_MyQueryConstruct():
     assert my_query.name == "MyQuery"
-    assert my_query.description == "This is my query."
     assert my_query.style == ExecutionStyle.Sequential
     assert my_query.requirements == [
         requirement1,


### PR DESCRIPTION
This is commit 2 of N to make RepoAuditor classes default constructable for easier command line processing.

Once these changes are complete, command line arguments will be passed to the modules as dictionaries rather than provided to modules as constructor arguments. This large set of changes is broken into smaller changes to make them easier to review.