### PR TITLE
Added CommandLineProcessor and using it with EntryPoint

### DIFF
--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -164,7 +164,7 @@ jobs:
     with:
       operating_system: ${{ matrix.os }}
       python_version: ${{ matrix.python_version }}
-      validation_command: RepoAuditor Version
+      validation_command: RepoAuditor --version
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ Repository = "https://github.com/gt-sse-center/RepoAuditor"
 [project.scripts]
 RepoAuditor = "RepoAuditor:EntryPoint.app"
 
+[project.entry-points.RepoAuditor]
+plugin1 = "RepoAuditor.Plugins.Plugin1"
+plugin2 = "RepoAuditor.Plugins.Plugin2"
+
 # ----------------------------------------------------------------------
 # |
 # |  black

--- a/src/RepoAuditor/CommandLineProcessor.py
+++ b/src/RepoAuditor/CommandLineProcessor.py
@@ -1,0 +1,150 @@
+# -------------------------------------------------------------------------------
+# |                                                                             |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
+# |                     Distributed under the MIT License.                      |
+# |                                                                             |
+# -------------------------------------------------------------------------------
+"""Contains the CommandLineProcessor object"""
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]
+
+from .ExecuteModules import Execute, Module, ModuleInfo
+
+
+# ----------------------------------------------------------------------
+@dataclass(frozen=True)
+class CommandLineProcessor:
+    """\
+    Object that makes it easy to process command line arguments and invoke ExecuteModules.Execute
+    in a testable way.
+    """
+
+    # ----------------------------------------------------------------------
+    # |
+    # |  Public Types
+    # |
+    # ----------------------------------------------------------------------
+    class GetDynamicArgsFunc(Protocol):
+        def __call__(
+            self,
+            dynamic_arg_definitions: dict[
+                str, Any
+            ],  # actual type is dict[str, TyperEx.TypeDefinitionItemType]
+        ) -> dict[str, Any]: ...
+
+    # ----------------------------------------------------------------------
+    # |
+    # |  Public Data
+    # |
+    # ----------------------------------------------------------------------
+    module_infos: list[ModuleInfo]
+    warnings_as_error_module_names: set[str]
+    ignore_warnings_module_names: set[str]
+    single_threaded: bool = field(kw_only=True)
+
+    # ----------------------------------------------------------------------
+    # |
+    # |  Public Methods
+    # |
+    # ----------------------------------------------------------------------
+    @classmethod
+    def Create(
+        cls,
+        get_dynamic_args_func: "CommandLineProcessor.GetDynamicArgsFunc",
+        modules: list[Module],
+        excludes: list[str],
+        warnings_as_error_module_names: set[str],
+        ignore_warnings_module_names: set[str],
+        *,
+        all_warnings_as_error: bool = False,
+        ignore_all_warnings: bool = False,
+        single_threaded: bool = False,
+        argument_separator: str = "-",
+    ) -> "CommandLineProcessor":
+        # Convert modules into a lookup map
+        module_map: dict[str, Module] = {}
+
+        for module in modules:
+            if argument_separator in module.name:
+                raise Exception(f"The module name '{module.name}' contains '{argument_separator}'.")
+
+            prev_module = module_map.get(module.name, None)
+            if prev_module is not None:
+                raise Exception(f"The module '{module.name}' has already been defined.")
+
+            module_map[module.name] = module
+
+        del modules
+
+        # Process excludes
+        excluded_requirements: dict[str, set[str]] = {}
+
+        for exclude in excludes:
+            parts = exclude.split(argument_separator)
+
+            this_module = module_map.get(parts[0], None)
+            if this_module is None:
+                raise Exception(f"'{parts[0]}' is not a recognized module name.")
+
+            if len(parts) == 1:
+                module_map.pop(parts[0])
+            else:
+                excluded_requirements.setdefault(this_module.name, set()).add(
+                    argument_separator.join(parts[1:])
+                )
+
+        del excludes
+
+        for module_name, excluded_requirement_names in excluded_requirements.items():
+            module = module_map[module_name]
+            module.RemoveRequirements(excluded_requirement_names)
+
+        del excluded_requirements
+
+        for module_name, module in list(module_map.items()):
+            if module.GetNumRequirements() == 0:
+                module_map.pop(module_name)
+
+        if all_warnings_as_error:
+            warnings_as_error_module_names = {module.name for module in module_map.values()}
+        if ignore_all_warnings:
+            ignore_warnings_module_names = {module.name for module in module_map.values()}
+
+        # Create the type definitions
+        dynamic_arg_definitions: dict[str, Any] = {}
+
+        for module in module_map.values():
+            for key, value in module.GetDynamicArgDefinitions().items():
+                dynamic_arg_definitions[f"{module.name}{argument_separator}{key}"] = value
+
+        # Process the dynamic info
+        dynamic_args: dict[str, dict[str, Any]] = {}
+
+        for key, value in get_dynamic_args_func(dynamic_arg_definitions).items():
+            parts = key.split(argument_separator)
+            assert len(parts) >= 2
+
+            if parts[0] not in module_map:
+                raise Exception(f"'{parts[0]}' is not a recognized module name.")
+
+            dynamic_args.setdefault(parts[0], {})[argument_separator.join(parts[1:])] = value
+
+        return cls(
+            [
+                ModuleInfo(module, dynamic_args.get(module_name, {}))
+                for module_name, module in module_map.items()
+            ],
+            warnings_as_error_module_names,
+            ignore_warnings_module_names,
+            single_threaded=single_threaded,
+        )
+
+    # ----------------------------------------------------------------------
+    def __call__(
+        self,
+        dm: DoneManager,
+    ) -> None:
+        Execute(dm, self.module_infos)

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -7,12 +7,26 @@
 """This file serves as an example of how to create scripts that can be invoked from the command line once the package is installed."""
 
 import sys
+import textwrap
 
+from typing import Annotated
+
+import pluggy
 import typer
 
+from click.exceptions import UsageError
+from dbrownell_Common.Streams.DoneManager import DoneManager, Flags as DoneManagerFlags  # type: ignore [import-untyped]
+from dbrownell_Common import TextwrapEx  # type: ignore [import-untyped]
+from dbrownell_Common import TyperEx  # type: ignore [import-untyped]
 from typer.core import TyperGroup  # type: ignore [import-untyped]
 
-from RepoAuditor import __version__
+from RepoAuditor import APP_NAME, __version__
+from RepoAuditor.CommandLineProcessor import CommandLineProcessor, Module
+from RepoAuditor import Plugin
+
+
+# ----------------------------------------------------------------------
+ARGUMENT_SEPARATOR = "-"
 
 
 # ----------------------------------------------------------------------
@@ -34,18 +48,182 @@ app = typer.Typer(
 
 
 # ----------------------------------------------------------------------
-@app.command("Placeholder")
-def Placeholder() -> None:
-    """This is a placeholder command that should be removed once actual functionality is added."""
-    pass
+def _GetModules() -> list[Module]:
+    plugin_manager = pluggy.PluginManager(APP_NAME)
+
+    plugin_manager.add_hookspecs(Plugin)
+    plugin_manager.load_setuptools_entrypoints(APP_NAME)
+
+    return plugin_manager.hook.GetModule()
+
+
+_all_modules = _GetModules()
+del _GetModules
 
 
 # ----------------------------------------------------------------------
-@app.command("Version")
-def Version() -> None:
-    """Prints the version of the package."""
+def _HelpEpilog() -> str:
+    content: list[str] = []
 
-    sys.stdout.write(__version__)
+    for module in _all_modules:
+        arguments: list[str] = []
+
+        for arg_name, type_info in module.GetDynamicArgDefinitions().items():
+            if isinstance(type_info, TyperEx.TypeDefinitionItem):
+                python_type = type_info.python_type
+                parameter_info = type_info.parameter_info
+            elif isinstance(type_info, tuple):
+                python_type = type_info[0]
+                parameter_info = type_info[1]
+            else:
+                python_type = type_info
+                parameter_info = None
+
+            arguments.append(
+                "    {arg_name:<32} {type_description:<8} {help}".format(
+                    arg_name=f"--{module.name}{ARGUMENT_SEPARATOR}{arg_name}",
+                    type_description=python_type.__name__,
+                    help="" if parameter_info is None else parameter_info.help,
+                ),
+            )
+
+        final_arguments = TextwrapEx.Indent(
+            "\n".join(arguments),
+            4,
+            skip_first_line=True,
+        )
+
+        content.append(
+            textwrap.dedent(
+                f"""\
+                {module.name}
+                {"-" * len(module.name)}
+                {module.description}
+
+                Command Line Arguments:
+                    {final_arguments}
+                """,
+            ),
+        )
+
+    return (
+        textwrap.dedent(
+            """\
+        Module Information
+        ==================
+
+        {}
+        """,
+        )
+        .format(
+            "\n".join(content),
+        )
+        .replace("\n", "\n\n")
+    )
+
+
+# ----------------------------------------------------------------------
+def _VersionCallback(value: bool) -> None:
+    if value:
+        sys.stdout.write(f"RepoAuditor v{__version__}\n")
+        raise typer.Exit()
+
+
+# ----------------------------------------------------------------------
+@app.command(
+    "EntryPoint",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+    help=__doc__,
+    epilog=_HelpEpilog(),
+    no_args_is_help=False,
+)
+def EntryPoint(
+    ctx: typer.Context,
+    version: Annotated[  # pylint: disable=unused-argument
+        bool,
+        typer.Option(
+            "--version",
+            help="Display the version of this tool and exit.",
+            callback=_VersionCallback,
+            is_eager=True,
+        ),
+    ] = False,
+    excludes: Annotated[
+        list[str],
+        typer.Option(
+            "--exclude",
+            help=f"Module or requirement names to exclude from execution; like other command line arguments, requirement names must include the module name as a prefix (e.g. 'ModuleName{ARGUMENT_SEPARATOR}RequirementName'). This value can be provided multiple times.",
+        ),
+    ] = [],
+    warnings_as_error: Annotated[
+        list[str],
+        typer.Option(
+            "--warnings-as-error",
+            help="Name of a module whose warnings should be treated as errors. This value can be provided multiple times.",
+        ),
+    ] = [],
+    ignore_warnings: Annotated[
+        list[str],
+        typer.Option(
+            "--ignore-warnings",
+            help="Name of a module whose warnings should be ignored. This value can be provided multiple times.",
+        ),
+    ] = [],
+    all_warnings_as_error: Annotated[
+        bool, typer.Option("--all-warnings-as-error", help="Treat all warnings as errors.")
+    ] = False,
+    ignore_all_warnings: Annotated[
+        bool, typer.Option("--ignore-all-warnings", help="Ignore all warnings.")
+    ] = False,
+    single_threaded: Annotated[
+        bool,
+        typer.Option(
+            "--single-threaded", help="Do not use multiple threads when evaluating requirements."
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            help="Write verbose information to the terminal.",
+        ),
+    ] = False,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            "--debug",
+            help="Write debug information to the terminal.",
+        ),
+    ] = False,
+) -> None:
+    with DoneManager.CreateCommandLine(
+        sys.stdout,
+        flags=DoneManagerFlags.Create(verbose=verbose, debug=debug),
+    ) as dm:
+        try:
+            executor = CommandLineProcessor.Create(
+                lambda dynamic_arg_definitions: TyperEx.ProcessDynamicArgs(
+                    ctx, dynamic_arg_definitions
+                ),
+                _all_modules,
+                excludes,
+                set(warnings_as_error),
+                set(ignore_warnings),
+                all_warnings_as_error=all_warnings_as_error,
+                ignore_all_warnings=ignore_all_warnings,
+                single_threaded=single_threaded,
+                argument_separator=ARGUMENT_SEPARATOR,
+            )
+
+        except Exception as ex:
+            if dm.is_debug:
+                raise
+
+            raise UsageError(str(ex)) from ex
+
+        dm.WriteLine("")
+
+        executor(dm)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugin.py
+++ b/src/RepoAuditor/Plugin.py
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------
+# |                                                                             |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
+# |                     Distributed under the MIT License.                      |
+# |                                                                             |
+# -------------------------------------------------------------------------------
+"""Contains the interface that Plugins must implement"""
+
+import pluggy
+
+from RepoAuditor import APP_NAME
+
+from .Module import Module
+
+
+# ----------------------------------------------------------------------
+@pluggy.HookspecMarker(APP_NAME)
+def GetModule() -> Module:
+    """Returns a Module"""
+    raise Exception("hookspec")  # pragma: no cover

--- a/src/RepoAuditor/Plugins/Plugin1.py
+++ b/src/RepoAuditor/Plugins/Plugin1.py
@@ -1,0 +1,96 @@
+# -------------------------------------------------------------------------------
+# |                                                                             |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
+# |                     Distributed under the MIT License.                      |
+# |                                                                             |
+# -------------------------------------------------------------------------------
+"""Contains the Plugin1 object"""
+
+from typing import Any, Optional
+
+import pluggy
+
+from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
+from dbrownell_Common.Types import override  # type: ignore[import-untyped]
+
+from RepoAuditor import APP_NAME
+from RepoAuditor.Plugin import Module
+from RepoAuditor.Query import ExecutionStyle, Query
+from RepoAuditor.Requirement import EvaluateResult, Requirement
+
+
+# ----------------------------------------------------------------------
+class Plugin1(Module):
+    # ----------------------------------------------------------------------
+    def __init__(self) -> None:
+        super(Plugin1, self).__init__(
+            "Plugin1",
+            "This is a description of Plugin1",
+            ExecutionStyle.Parallel,
+            [_Query()],
+        )
+
+    # ----------------------------------------------------------------------
+    @override
+    def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        return {
+            "foo": int,
+        }
+
+    # ----------------------------------------------------------------------
+    @override
+    def GenerateInitialData(self, dynamic_args: dict[str, Any]) -> dict[str, Any]:
+        if "foo" not in dynamic_args:
+            raise Exception("'foo' is a required argument.")
+
+        return dynamic_args
+
+
+# ----------------------------------------------------------------------
+@pluggy.HookimplMarker(APP_NAME)
+def GetModule() -> Module:
+    return Plugin1()
+
+
+# ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+class _Requirement(Requirement):
+    # ----------------------------------------------------------------------
+    def __init__(self):
+        super(_Requirement, self).__init__(
+            "Requirement1",
+            "A description of the requirement.",
+            ExecutionStyle.Sequential,
+            "resolution_template",
+            "rationale_template",
+        )
+
+    # ----------------------------------------------------------------------
+    # ----------------------------------------------------------------------
+    # ----------------------------------------------------------------------
+    @override
+    def _EvaluateImpl(
+        self,
+        query_data: dict[str, Any],
+    ) -> tuple[EvaluateResult, Optional[str]]:
+        return EvaluateResult.Success, None
+
+
+# ----------------------------------------------------------------------
+class _Query(Query):
+    # ----------------------------------------------------------------------
+    def __init__(self):
+        super(_Query, self).__init__(
+            "Query1",
+            ExecutionStyle.Sequential,
+            [_Requirement()],
+        )
+
+    # ----------------------------------------------------------------------
+    @override
+    def GetData(
+        self,
+        module_data: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        return module_data

--- a/src/RepoAuditor/Plugins/Plugin2.py
+++ b/src/RepoAuditor/Plugins/Plugin2.py
@@ -1,0 +1,49 @@
+# -------------------------------------------------------------------------------
+# |                                                                             |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
+# |                     Distributed under the MIT License.                      |
+# |                                                                             |
+# -------------------------------------------------------------------------------
+"""Contains the Plugin2 object"""
+
+from typing import Any
+
+import pluggy
+
+from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
+from dbrownell_Common.Types import override  # type: ignore[import-untyped]
+
+from RepoAuditor import APP_NAME
+from RepoAuditor.Plugin import Module
+from RepoAuditor.Query import ExecutionStyle
+
+
+# ----------------------------------------------------------------------
+class Plugin2(Module):
+    # ----------------------------------------------------------------------
+    def __init__(self) -> None:
+        super(Plugin2, self).__init__(
+            "Plugin2",
+            "This is a description of Plugin2",
+            ExecutionStyle.Parallel,
+            [],
+        )
+
+    # ----------------------------------------------------------------------
+    @override
+    def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        return {
+            "foo": int,
+        }
+
+    # ----------------------------------------------------------------------
+    @override
+    def GenerateInitialData(self, dynamic_args: dict[str, Any]) -> dict[str, Any]:
+        assert "foo" in dynamic_args
+        return dynamic_args
+
+
+# ----------------------------------------------------------------------
+@pluggy.HookimplMarker(APP_NAME)
+def GetModule() -> Module:
+    return Plugin2()

--- a/src/RepoAuditor/__init__.py
+++ b/src/RepoAuditor/__init__.py
@@ -6,6 +6,8 @@
 # ----------------------------------------------------------------------
 # pylint: disable=missing-module-docstring,invalid-name
 
+APP_NAME = "RepoAuditor"
+
 # Note that this value will be overwritten by calls to `python ../../Build.py update_version` based
 # on changes observed in the git repository. The default value below will be used until the value
 # here is explicitly updated as part of a commit.

--- a/tests/CommandLineProcessor_UnitTest.py
+++ b/tests/CommandLineProcessor_UnitTest.py
@@ -1,0 +1,343 @@
+# -------------------------------------------------------------------------------
+# |                                                                             |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
+# |                     Distributed under the MIT License.                      |
+# |                                                                             |
+# -------------------------------------------------------------------------------
+"""Unit test for CommandLineProcessor.py"""
+
+import re
+import textwrap
+
+from typing import cast, ClassVar, Optional
+from unittest.mock import patch
+
+import pytest
+
+from dbrownell_Common.TestHelpers.StreamTestHelpers import GenerateDoneManagerAndContent
+from dbrownell_Common.Types import override
+
+from RepoAuditor.CommandLineProcessor import *
+from RepoAuditor.Module import TypeDefinitionItemType
+from RepoAuditor.Query import Query
+from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
+
+
+# ----------------------------------------------------------------------
+# |
+# |  Public Types
+# |
+# ----------------------------------------------------------------------
+class MyModule(Module):
+    # ----------------------------------------------------------------------
+    def __init__(
+        self,
+        name: str = "MyModule",
+        dynamic_args: Optional[dict[str, Any]] = None,
+    ):
+        super(MyModule, self).__init__(
+            name,
+            "",
+            ExecutionStyle.Sequential,
+            [MyQuery()],
+        )
+
+        self.dynamic_args = dynamic_args
+
+    # ----------------------------------------------------------------------
+    @override
+    def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        return self.dynamic_args or {}
+
+    # ----------------------------------------------------------------------
+    @override
+    def GenerateInitialData(
+        self,
+        dynamic_args: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        assert not dynamic_args
+        return dynamic_args
+
+
+# ----------------------------------------------------------------------
+class MyQuery(Query):
+    # ----------------------------------------------------------------------
+    def __init__(self):
+        super(MyQuery, self).__init__(
+            "MyQuery",
+            ExecutionStyle.Sequential,
+            [
+                MyRequirement("Requirement1"),
+                MyRequirement("Requirement2"),
+            ],
+        )
+
+    # ----------------------------------------------------------------------
+    @override
+    def GetData(
+        self,
+        module_data: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        return module_data
+
+
+# ----------------------------------------------------------------------
+class MyRequirement(Requirement):
+    # ----------------------------------------------------------------------
+    def __init__(self, name: str):
+        super(MyRequirement, self).__init__(
+            name,
+            "",
+            ExecutionStyle.Sequential,
+            "",
+            "",
+        )
+
+    # ----------------------------------------------------------------------
+    @override
+    def _EvaluateImpl(
+        self,
+        query_data: dict[str, Any],
+    ) -> tuple[EvaluateResult, Optional[str]]:
+        raise Exception("This should never be invoked")
+
+
+# ----------------------------------------------------------------------
+# |
+# |  Public Functions
+# |
+# ----------------------------------------------------------------------
+def test_Standard():
+    clp = CommandLineProcessor.Create(
+        lambda *args: {"MyModule-arg1": False},
+        [MyModule()],
+        [],
+        set(),
+        set(),
+    )
+
+    assert len(clp.module_infos) == 1
+    assert isinstance(clp.module_infos[0].module, MyModule)
+    assert clp.module_infos[0].module.GetNumRequirements() == 2
+    assert clp.module_infos[0].dynamic_args == {"arg1": False}
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+    dm_and_content = GenerateDoneManagerAndContent()
+
+    with patch("RepoAuditor.CommandLineProcessor.Execute") as mock_execute:
+        clp(next(dm_and_content))
+
+    assert len(mock_execute.call_args_list) == 1
+
+    args = mock_execute.call_args_list[0].args
+    kwargs = mock_execute.call_args_list[0].kwargs
+
+    assert len(args) == 2
+
+    assert isinstance(args[0], DoneManager)
+    assert args[1] == clp.module_infos
+
+    assert kwargs == {}
+
+    assert cast(str, next(dm_and_content)) == textwrap.dedent(
+        """\
+        Heading...DONE! (0, <scrubbed duration>)
+        """,
+    )
+
+
+# ----------------------------------------------------------------------
+def test_WithDynamicArgs():
+    clp = CommandLineProcessor.Create(
+        lambda *args: {
+            "MyModule-arg1": False,
+            "MyModule-one": 1,
+            "MyModule-two": 2,
+        },
+        [MyModule(dynamic_args={"one": int, "two": int})],
+        [],
+        set(),
+        set(),
+    )
+
+    assert len(clp.module_infos) == 1
+    assert isinstance(clp.module_infos[0].module, MyModule)
+    assert clp.module_infos[0].module.GetNumRequirements() == 2
+    assert clp.module_infos[0].dynamic_args == {
+        "arg1": False,
+        "one": 1,
+        "two": 2,
+    }
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+def test_ExcludeModule():
+    clp = CommandLineProcessor.Create(
+        lambda *args: {},
+        [MyModule()],
+        ["MyModule"],
+        set(),
+        set(),
+    )
+
+    assert not clp.module_infos
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("sep", ["-", "__--__"])
+def test_ExcludeRequirement(sep):
+    clp = CommandLineProcessor.Create(
+        lambda *args: {f"MyModule{sep}arg1": False},
+        [MyModule()],
+        [f"MyModule{sep}Requirement1"],
+        set(),
+        set(),
+        argument_separator=sep,
+    )
+
+    assert len(clp.module_infos) == 1
+    assert clp.module_infos[0].module.GetNumRequirements() == 1
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+def test_ExcludeAllRequirements():
+    clp = CommandLineProcessor.Create(
+        lambda *args: {},
+        [MyModule()],
+        ["MyModule-Requirement1", "MyModule-Requirement2"],
+        set(),
+        set(),
+    )
+
+    assert not clp.module_infos
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("sep", ["-", "__--__"])
+def test_CommandLineArgs(sep):
+    clp = CommandLineProcessor.Create(
+        lambda *args: {
+            f"MyModule{sep}arg1": True,
+        },
+        [MyModule()],
+        [],
+        set(),
+        set(),
+        argument_separator=sep,
+    )
+
+    assert len(clp.module_infos) == 1
+    assert clp.module_infos[0].module.GetNumRequirements() == 2
+    assert clp.module_infos[0].dynamic_args == {"arg1": True}
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+def test_AllWarningsAsError():
+    clp = CommandLineProcessor.Create(
+        lambda *args: {"MyModule-arg1": False},
+        [MyModule()],
+        [],
+        set(),
+        set(),
+        all_warnings_as_error=True,
+    )
+
+    assert len(clp.module_infos) == 1
+    assert clp.warnings_as_error_module_names == {"MyModule"}
+    assert clp.ignore_warnings_module_names == set()
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+def test_IgnoreAllWarnings():
+    clp = CommandLineProcessor.Create(
+        lambda *args: {"MyModule-arg1": False},
+        [MyModule()],
+        [],
+        set(),
+        set(),
+        ignore_all_warnings=True,
+    )
+
+    assert len(clp.module_infos) == 1
+    assert clp.warnings_as_error_module_names == set()
+    assert clp.ignore_warnings_module_names == {"MyModule"}
+    assert clp.single_threaded is False
+
+
+# ----------------------------------------------------------------------
+def test_ErrorInvalidModuleName():
+    with pytest.raises(
+        Exception,
+        match=re.escape("The module name 'Invalid-name' contains '-'."),
+    ):
+        CommandLineProcessor.Create(
+            lambda *args: {},
+            [MyModule("Invalid-name")],
+            [],
+            set(),
+            set(),
+        )
+
+
+# ----------------------------------------------------------------------
+def test_ErrorDuplicateName():
+    with pytest.raises(
+        Exception,
+        match=re.escape("The module 'MyModule' has already been defined."),
+    ):
+        CommandLineProcessor.Create(
+            lambda *args: {},
+            [MyModule(), MyModule()],
+            [],
+            set(),
+            set(),
+        )
+
+
+# ----------------------------------------------------------------------
+def test_ErrorInvalidExcludeName():
+    with pytest.raises(
+        Exception,
+        match=re.escape("'DoesNotExist' is not a recognized module name."),
+    ):
+        CommandLineProcessor.Create(
+            lambda *args: {"MyModule-arg1": False},
+            [MyModule()],
+            ["DoesNotExist"],
+            set(),
+            set(),
+        )
+
+
+# ----------------------------------------------------------------------
+def test_InvalidArgName():
+    with pytest.raises(
+        Exception,
+        match=re.escape("'MyModule' is not a recognized module name."),
+    ):
+        # This code provides an argument for a module that has been excluded
+        CommandLineProcessor.Create(
+            lambda *args: {"MyModule-arg1": False},
+            [MyModule()],
+            ["MyModule"],
+            set(),
+            set(),
+        )

--- a/tests/EntryPoint_UnitTest.py
+++ b/tests/EntryPoint_UnitTest.py
@@ -8,12 +8,48 @@
 
 from typer.testing import CliRunner
 
+from RepoAuditor import __version__
 from RepoAuditor.EntryPoint import app
 
 
 # ----------------------------------------------------------------------
 def test_Version() -> None:
-    result = CliRunner().invoke(app, ["Version"])
+    result = CliRunner().invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output == f"RepoAuditor v{__version__}\n"
+
+
+# ----------------------------------------------------------------------
+def test_Standard() -> None:
+    result = CliRunner().invoke(app, ["--Plugin1-foo", "10"])
 
     assert result.exit_code == 0
     assert result.output
+
+
+# ----------------------------------------------------------------------
+def test_Exception() -> None:
+    result = CliRunner().invoke(app, [])
+
+    assert result.exit_code != 0
+
+    # Don't assert as a single string as the "ERROR:" prefix is decorated with colors
+    assert "ERROR:" in result.output
+    assert "'foo' is a required argument." in result.output
+
+
+# ----------------------------------------------------------------------
+def test_ExceptionWithDebug() -> None:
+    result = CliRunner().invoke(app, ["--debug"])
+
+    assert result.exit_code != 0
+    assert "Exception: 'foo' is a required argument" in result.output
+
+
+# ----------------------------------------------------------------------
+def test_Help() -> None:
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Module Information" in result.output

--- a/tests/Plugin_UnitTest.py
+++ b/tests/Plugin_UnitTest.py
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------------------------
+# |                                                                             |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
+# |                     Distributed under the MIT License.                      |
+# |                                                                             |
+# -------------------------------------------------------------------------------
+"""Unit tests for Plugin.py"""
+
+from RepoAuditor.Plugin import *
+
+
+# ----------------------------------------------------------------------
+def test_Placeholder():
+    # There isn't really anything to test here, but create a placeholder test so that pytest doesn't complain
+    assert True


### PR DESCRIPTION
This is commit 4 of 4 to make RepoAuditor classes default constructable for easier command line processing.

Once these changes are complete, command line arguments will be passed to the modules as dictionaries rather than provided to modules as constructor arguments. This large set of changes is broken into smaller changes to make them easier to review.