### PR TITLE
Modules/Requirements that only run when explicitly included

### DIFF
--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -137,7 +137,7 @@ def _VersionCallback(value: bool) -> None:
     epilog=_HelpEpilog(),
     no_args_is_help=False,
 )
-def EntryPoint(
+def EntryPoint(  # pylint: disable=dangerous-default-value
     ctx: typer.Context,
     version: Annotated[  # pylint: disable=unused-argument
         bool,
@@ -148,6 +148,13 @@ def EntryPoint(
             is_eager=True,
         ),
     ] = False,
+    includes: Annotated[
+        list[str],
+        typer.Option(
+            "--include",
+            help=f"Module or requirement names to explicitly include in the execution; like other command line arguments, requirement names must include the module name as a prefix (e.g. 'ModuleName{ARGUMENT_SEPARATOR}RequirementName'). This value can be provided multiple times.",
+        ),
+    ] = [],
     excludes: Annotated[
         list[str],
         typer.Option(
@@ -206,6 +213,7 @@ def EntryPoint(
                     ctx, dynamic_arg_definitions
                 ),
                 _all_modules,
+                includes,
                 excludes,
                 set(warnings_as_error),
                 set(ignore_warnings),

--- a/src/RepoAuditor/Module.py
+++ b/src/RepoAuditor/Module.py
@@ -44,20 +44,24 @@ class Module(ABC):
         description: str,
         style: ExecutionStyle,
         queries: list[Query],
+        *,
+        requires_explicit_include: bool = False,  # If True, the module must be explicitly included on the command line
     ) -> None:
         self.name = name
         self.description = description
         self.style = style
         self.queries = queries
+        self.requires_explicit_include = requires_explicit_include
 
     # ----------------------------------------------------------------------
     def GetNumRequirements(self) -> int:
         return sum(len(query.requirements) for query in self.queries)
 
     # ----------------------------------------------------------------------
-    def RemoveRequirements(
+    def ProcessRequirements(
         self,
-        requirement_names: set[str],
+        included_names: set[str],
+        excluded_names: set[str],
     ) -> None:
         query_index = 0
 
@@ -69,7 +73,9 @@ class Module(ABC):
             while requirement_index < len(query.requirements):
                 requirement = query.requirements[requirement_index]
 
-                if requirement.name in requirement_names:
+                if (
+                    requirement.requires_explicit_include and requirement.name not in included_names
+                ) or (requirement.name in excluded_names):
                     query.requirements.pop(requirement_index)
                     continue
 

--- a/src/RepoAuditor/Requirement.py
+++ b/src/RepoAuditor/Requirement.py
@@ -58,6 +58,8 @@ class Requirement(ABC):
         style: ExecutionStyle,
         resolution_template: str,
         rationale_template: str,
+        *,
+        requires_explicit_include: bool = False,  # If True, the requirement must be explicitly included on the command line
     ) -> None:
         self.name = name
         self.description = description
@@ -65,6 +67,8 @@ class Requirement(ABC):
 
         self.resolution_template = resolution_template
         self.rationale_template = rationale_template
+
+        self.requires_explicit_include = requires_explicit_include
 
     # ----------------------------------------------------------------------
     def Evaluate(

--- a/tests/Requirement_UnitTest.py
+++ b/tests/Requirement_UnitTest.py
@@ -25,9 +25,16 @@ class MyRequirement(Requirement):
         rationale_template: str,
         expected_result: EvaluateResult,
         context: Optional[str] = None,
+        *,
+        requires_explicit_include: bool = False,
     ) -> None:
         super(MyRequirement, self).__init__(
-            name, description, style, resolution_template, rationale_template
+            name,
+            description,
+            style,
+            resolution_template,
+            rationale_template,
+            requires_explicit_include=requires_explicit_include,
         )
 
         self.expected_result = expected_result
@@ -53,9 +60,17 @@ def test_Construct():
     rationale_template = Mock()
     expected_result = Mock()
     context = Mock()
+    requires_explicit_include = Mock()
 
     r = MyRequirement(
-        name, description, style, resolution_template, rationale_template, expected_result, context
+        name,
+        description,
+        style,
+        resolution_template,
+        rationale_template,
+        expected_result,
+        context,
+        requires_explicit_include=requires_explicit_include,
     )
 
     assert r.name is name
@@ -65,6 +80,7 @@ def test_Construct():
     assert r.rationale_template is rationale_template
     assert r.expected_result is expected_result
     assert r.context is context
+    assert r.requires_explicit_include is requires_explicit_include
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Introduced functionality where Modules and Requirements can opt-in to a behavior where they will only be run if explicitly specified on the command line. This can be used for long-running modules/requirements or those that verify unusual/non-standard functionality.