### PR TITLE
Updated copyright display format

### DIFF
--- a/src/RepoAuditor/CommandLineProcessor.py
+++ b/src/RepoAuditor/CommandLineProcessor.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the CommandLineProcessor object"""
 

--- a/src/RepoAuditor/ExecuteModules.py
+++ b/src/RepoAuditor/ExecuteModules.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains functionality to execute multiple Modules"""
 

--- a/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
+++ b/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains functionality to process items in parallel and/or sequentially."""
 

--- a/src/RepoAuditor/Module.py
+++ b/src/RepoAuditor/Module.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the Module object and types used in its definition"""
 

--- a/src/RepoAuditor/Plugin.py
+++ b/src/RepoAuditor/Plugin.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the interface that Plugins must implement"""
 

--- a/src/RepoAuditor/Plugins/GitHub/Impl/Common.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/Common.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains common functionality that is used across different components."""
 

--- a/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the EnableRequirementImpl object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the ValueRequirementImpl object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/Module.py
+++ b/src/RepoAuditor/Plugins/GitHub/Module.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the GitHubModule object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the StandardQuery object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the AutoMerge object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the DefaultBranch object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the DeleteHeadBranches object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the DependabotSecurityUpdates object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the Description object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the License object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the MergeCommit object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the MergeCommitMessage object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the Private object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the RebaseMergeCommit object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SecretScanning object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SecretScanningPushProtection object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SquashCommitMerge object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SquashMergeCommitMessage object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SuggestUpdatingPullRequestBranches object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SupportDiscussions object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SupportIssues object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SupportProjects object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the SupportWikis object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the TemplateRepository object"""
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the WebCommitSignoff object"""
 

--- a/src/RepoAuditor/Plugins/GitHubPlugin.py
+++ b/src/RepoAuditor/Plugins/GitHubPlugin.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains Plugin functionality"""
 

--- a/src/RepoAuditor/Query.py
+++ b/src/RepoAuditor/Query.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains the Query object and types used in its definition"""
 

--- a/src/RepoAuditor/Requirement.py
+++ b/src/RepoAuditor/Requirement.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Contains types used when creating Requirements."""
 

--- a/tests/CommandLineProcessor_UnitTest.py
+++ b/tests/CommandLineProcessor_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit test for CommandLineProcessor.py"""
 

--- a/tests/EntryPoint_UnitTest.py
+++ b/tests/EntryPoint_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit tests for EntryPoint.py"""
 

--- a/tests/ExecuteModules_UnitTest.py
+++ b/tests/ExecuteModules_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit test for Executor.py"""
 

--- a/tests/Module_UnitTest.py
+++ b/tests/Module_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit test for Module.py"""
 

--- a/tests/Plugin_UnitTest.py
+++ b/tests/Plugin_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit tests for Plugin.py"""
 

--- a/tests/Plugins/GitHub_EndToEndTest.py
+++ b/tests/Plugins/GitHub_EndToEndTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """End-to-end tests for the GitHub plugin"""
 

--- a/tests/Query_UnitTest.py
+++ b/tests/Query_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit test for Query.py"""
 

--- a/tests/Requirement_UnitTest.py
+++ b/tests/Requirement_UnitTest.py
@@ -1,8 +1,8 @@
 # -------------------------------------------------------------------------------
-# |                                                                             |
-# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
-# |                     Distributed under the MIT License.                      |
-# |                                                                             |
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
 # -------------------------------------------------------------------------------
 """Unit tests for Requirement.py"""
 


### PR DESCRIPTION
## :pencil: Description
While displaying the copyright information in a box was pretty, it was an idea that was doomed from the start - the pretty box will be ruined once additional information is embedded within the longest line. For example:

Original pretty box:
```python
# -------------------------------------------------------------------------------
# |                                                                             |
# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech  |
# |                     Distributed under the MIT License.                      |
# |                                                                             |
# -------------------------------------------------------------------------------
```

With modifications:

```python
# -------------------------------------------------------------------------------
# |                                                                             |
# |  Copyright (c) 2024-25 Scientific Software Engineering Center at Georgia Tech  |
# |                     Distributed under the MIT License.                      |
# |                                                                             |
# -------------------------------------------------------------------------------
```

## :gear: Work Item
N/A

## :movie_camera: Demo
![image](https://github.com/user-attachments/assets/2ecd556a-5695-4ea6-b34a-8da6d006fa39)
