### PR TITLE
Rename "secret scanning" to "secret protection"

### DIFF
--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -22,12 +22,12 @@ class SecretScanning(StandardEnableRequirementImpl):
             True,
             "false",
             "settings/security_analysis",
-            "Secret scanning",
-            "Secret scanning",
+            "Secret Protection",
+            "Secret protection",
             _GetValue,
             textwrap.dedent(
                 """\
-                The default behavior is to enable secret scanning.
+                The default behavior is to enable secret protection.
 
                 Reasons for this Default
                 ------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -22,7 +22,7 @@ class SecretScanningPushProtection(StandardEnableRequirementImpl):
             True,
             "false",
             "settings/security_analysis",
-            "Secret scanning",
+            "Secret Protection",
             "Push protection",
             _GetValue,
             textwrap.dedent(


### PR DESCRIPTION
…protection

## :pencil: Description

Fix name of github setting section from "Secret Scanning" to "Secret Protection".

Since the REST API still uses `secret_scanning` internally, I opted to keep class names consistent with the REST API, and only update the error messages displayed to the user.

## :gear: Work Item

Original issue and discussion: #41 

## :movie_camera: Demo

Output error message after changes (I executed that on one of my own repos)

![image](https://github.com/user-attachments/assets/8076912c-8c1c-4e3e-be52-2c66fab53f2d)
