### PR TITLE
Address ruff EM ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ select = [
     "DTZ",
     "T10",
     "DJ",
-    # "EM", # 9
+    "EM", # 9
     "EXE",
     "FIX",
     "FA",

--- a/src/RepoAuditor/CommandLineProcessor.py
+++ b/src/RepoAuditor/CommandLineProcessor.py
@@ -70,11 +70,13 @@ class CommandLineProcessor:
 
         for module in modules:
             if argument_separator in module.name:
-                raise Exception(f"The module name '{module.name}' contains '{argument_separator}'.")
+                msg = f"The module name '{module.name}' contains '{argument_separator}'."
+                raise Exception(msg)
 
             prev_module = module_map.get(module.name, None)
             if prev_module is not None:
-                raise Exception(f"The module '{module.name}' has already been defined.")
+                msg = f"The module '{module.name}' has already been defined."
+                raise Exception(msg)
 
             module_map[module.name] = module
 
@@ -89,7 +91,8 @@ class CommandLineProcessor:
 
             this_module = module_map.get(parts[0], None)
             if this_module is None:
-                raise Exception(f"'{parts[0]}' is not a recognized module name.")
+                msg = f"'{parts[0]}' is not a recognized module name."
+                raise Exception(msg)
 
             if len(parts) == 1:
                 included_modules.add(parts[0])
@@ -115,7 +118,8 @@ class CommandLineProcessor:
 
             this_module = module_map.get(parts[0], None)
             if this_module is None:
-                raise Exception(f"'{parts[0]}' is not a recognized module name.")
+                msg = f"'{parts[0]}' is not a recognized module name."
+                raise Exception(msg)
 
             if len(parts) == 1:
                 module_map.pop(parts[0])
@@ -168,7 +172,8 @@ class CommandLineProcessor:
             assert len(parts) >= 2
 
             if parts[0] not in module_map:
-                raise Exception(f"'{parts[0]}' is not a recognized module name.")
+                msg = f"'{parts[0]}' is not a recognized module name."
+                raise Exception(msg)
 
             if len(parts) == 2:
                 dynamic_args.setdefault(parts[0], {})[parts[1]] = value

--- a/src/RepoAuditor/Module.py
+++ b/src/RepoAuditor/Module.py
@@ -92,7 +92,7 @@ class Module(ABC):
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
         """Returns information about dynamic arguments that the module can consume (often from the command line)."""
 
-        raise Exception("Abstract method")  # pragma: no cover
+        raise Exception("Abstract method")  # pragma: no cover # noqa: EM101
 
     # ----------------------------------------------------------------------
     @abstractmethod
@@ -107,7 +107,7 @@ class Module(ABC):
         exception to indicate that the command line data is invalid.
         """
 
-        raise Exception("Abstract method")  # pragma: no cover
+        raise Exception("Abstract method")  # pragma: no cover # noqa: EM101
 
     # ----------------------------------------------------------------------
     def Evaluate(

--- a/src/RepoAuditor/Plugin.py
+++ b/src/RepoAuditor/Plugin.py
@@ -17,4 +17,4 @@ from .Module import Module
 @pluggy.HookspecMarker(APP_NAME)
 def GetModule() -> Module:
     """Returns a Module"""
-    raise Exception("hookspec")  # pragma: no cover
+    raise Exception("hookspec")  # pragma: no cover # noqa: EM101

--- a/src/RepoAuditor/Plugins/GitHub/Module.py
+++ b/src/RepoAuditor/Plugins/GitHub/Module.py
@@ -114,7 +114,8 @@ class _GitHubSession(requests.Session):
         path_parts = url_parts.path.split("/")
 
         if len(path_parts) != 3:
-            raise ValueError(f"'{github_url}' is not a valid GitHub repository URL.")
+            msg = f"'{github_url}' is not a valid GitHub repository URL."
+            raise ValueError(msg)
 
         _, username, repo = path_parts
 


### PR DESCRIPTION
## :pencil: Description

Enable ruff rule `EM` and address linter errors.
There were two types of `EM` errors:
* f-strings in the error constructor --> I changed those to a separate variable as suggested by ruff
* regular string in the error constructor --> I kept those and added a `noqa: EM101` error suppression

## :gear: Work Item

#57 (part of TODO list)

## :movie_camera: Demo

Error message before:
![image](https://github.com/user-attachments/assets/3162e959-a50c-48cb-9feb-c07ceceb558e)
