### PR TITLE
Address ruff ANN ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ select = [
     #"ERA", # 168
     "FAST",
     "YTT",
-    # "ANN", # 41
+    "ANN",
     "ASYNC",
     "S",
     "BLE",

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -34,7 +34,7 @@ ARGUMENT_SEPARATOR = "-"
 # ----------------------------------------------------------------------
 class NaturalOrderGrouper(TyperGroup):
     # ----------------------------------------------------------------------
-    def list_commands(self, *args, **kwargs):
+    def list_commands(self, *args, **kwargs) -> list[str]:
         return self.commands.keys()
 
 

--- a/src/RepoAuditor/ExecuteModules.py
+++ b/src/RepoAuditor/ExecuteModules.py
@@ -129,7 +129,7 @@ def Execute(
         if parallel:
             # ----------------------------------------------------------------------
             def Prepare(
-                context: Any,
+                context: Any,  # noqa: ANN401
                 on_simple_status_func: Callable[[str], None],
             ) -> tuple[int, ExecuteTasks.TransformTasksExTypes.TransformFuncType]:
                 module_info = cast(ModuleInfo, context)
@@ -140,7 +140,7 @@ def Execute(
                     status: ExecuteTasks.Status,
                 ) -> ExecuteTasks.TransformResultComplete:
                     # ----------------------------------------------------------------------
-                    def OnStatus(num_completed: int, *args, **kwargs):
+                    def OnStatus(num_completed: int, *args, **kwargs) -> None:
                         status.OnProgress(
                             num_completed,
                             _CreateStatusString(*args, **kwargs),

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class AllowDeletions(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(AllowDeletions, self).__init__(
             "AllowDeletions",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class AllowForcePushes(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(AllowForcePushes, self).__init__(
             "AllowForcePushes",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
@@ -16,7 +16,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class DismissStalePullRequestApprovals(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(DismissStalePullRequestApprovals, self).__init__(
             "DismissStalePullRequestApprovals",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class DoNotAllowBypassSettings(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(DoNotAllowBypassSettings, self).__init__(
             "DoNotAllowBypassSettings",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
@@ -20,7 +20,7 @@ from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
 # ----------------------------------------------------------------------
 class EnsureStatusChecks(Requirement):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(EnsureStatusChecks, self).__init__(
             "EnsureStatusChecks",
             "Ensure that status checks have been enabled for the branch.",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
@@ -16,7 +16,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireApprovalMostRecentPush(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireApprovalMostRecentPush, self).__init__(
             "RequireApprovalMostRecentPush",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
@@ -16,7 +16,7 @@ from .Impl.ClassicValueRequirementImpl import ClassicValueRequirementImpl, DoesN
 # ----------------------------------------------------------------------
 class RequireApprovals(ClassicValueRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireApprovals, self).__init__(
             "RequireApprovals",
             "1",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
@@ -16,7 +16,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireCodeOwnerReview(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireCodeOwnerReview, self).__init__(
             "RequireCodeOwnerReview",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireConversationResolution(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireConversationResolution, self).__init__(
             "RequireConversationResolution",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireLinearHistory(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireLinearHistory, self).__init__(
             "RequireLinearHistory",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequirePullRequests(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequirePullRequests, self).__init__(
             "RequirePullRequests",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireSignedCommits(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireSignedCommits, self).__init__(
             "RequireSignedCommits",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
@@ -14,7 +14,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireStatusChecksToPass(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireStatusChecksToPass, self).__init__(
             "RequireStatusChecksToPass",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
@@ -16,7 +16,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RequireUpToDateBranches(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RequireUpToDateBranches, self).__init__(
             "RequireUpToDateBranches",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
@@ -22,7 +22,7 @@ from ..Impl.Common import CreateIncompleteDataResult
 # ----------------------------------------------------------------------
 class Protected(Requirement):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         # Note that protected is set for the branch when creating a branch ruleset or a classic
         # branch protection rule.
         super(Protected, self).__init__(

--- a/src/RepoAuditor/Plugins/GitHub/Module.py
+++ b/src/RepoAuditor/Plugins/GitHub/Module.py
@@ -140,7 +140,7 @@ class _GitHubSession(requests.Session):
         url: str,
         *args,
         **kwargs,
-    ):
+    ) -> requests.Response:
         if url and not url.startswith("/"):
             url = f"/{url}"
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class AutoMerge(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(AutoMerge, self).__init__(
             "AutoMerge",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
@@ -14,7 +14,7 @@ from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
 # ----------------------------------------------------------------------
 class DefaultBranch(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(DefaultBranch, self).__init__(
             "DefaultBranch",
             "main",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class DeleteHeadBranches(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(DeleteHeadBranches, self).__init__(
             "DeleteHeadBranches",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
@@ -16,7 +16,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class DependabotSecurityUpdates(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(DependabotSecurityUpdates, self).__init__(
             "DependabotSecurityUpdates",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
@@ -23,7 +23,7 @@ from ..Impl.Common import CreateIncompleteDataResult
 # ----------------------------------------------------------------------
 class Description(Requirement):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(Description, self).__init__(
             "Description",
             "Validates a repository's description.",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
@@ -16,7 +16,7 @@ from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
 # ----------------------------------------------------------------------
 class License(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(License, self).__init__(
             "License",
             "MIT License",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class MergeCommit(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(MergeCommit, self).__init__(
             "MergeCommit",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
@@ -16,7 +16,7 @@ from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValue
 # ----------------------------------------------------------------------
 class MergeCommitMessage(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(MergeCommitMessage, self).__init__(
             "MergeCommitMessage",
             "BLANK",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
@@ -22,7 +22,7 @@ from ..Impl.Common import CreateIncompleteDataResult
 # ----------------------------------------------------------------------
 class Private(Requirement):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(Private, self).__init__(
             "Private",
             "Validates that the repository is set to the expected visibility.",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class RebaseMergeCommit(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(RebaseMergeCommit, self).__init__(
             "RebaseMergeCommit",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -16,7 +16,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SecretScanning(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SecretScanning, self).__init__(
             "SecretScanning",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -16,7 +16,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SecretScanningPushProtection(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SecretScanningPushProtection, self).__init__(
             "SecretScanningPushProtection",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SquashCommitMerge(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SquashCommitMerge, self).__init__(
             "SquashCommitMerge",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
@@ -16,7 +16,7 @@ from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValue
 # ----------------------------------------------------------------------
 class SquashMergeCommitMessage(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SquashMergeCommitMessage, self).__init__(
             "SquashMergeCommitMessage",
             "COMMIT_MESSAGES",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SuggestUpdatingPullRequestBranches(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SuggestUpdatingPullRequestBranches, self).__init__(
             "SuggestUpdatingPullRequestBranches",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SupportDiscussions(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SupportDiscussions, self).__init__(
             "SupportDiscussions",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SupportIssues(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SupportIssues, self).__init__(
             "SupportIssues",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SupportProjects(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SupportProjects, self).__init__(
             "SupportProjects",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class SupportWikis(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(SupportWikis, self).__init__(
             "SupportWikis",
             True,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class TemplateRepository(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(TemplateRepository, self).__init__(
             "TemplateRepository",
             False,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
@@ -14,7 +14,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 # ----------------------------------------------------------------------
 class WebCommitSignoff(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         super(WebCommitSignoff, self).__init__(
             "WebCommitSignoff",
             True,

--- a/src/RepoAuditor/Query.py
+++ b/src/RepoAuditor/Query.py
@@ -132,7 +132,7 @@ class StatusInfo:
     """Class used to store information required by OnStatusFunc."""
 
     # ----------------------------------------------------------------------
-    def __init__(self):
+    def __init__(self) -> None:
         self.num_completed: int = 0
         self.num_success: int = 0
         self.num_error: int = 0


### PR DESCRIPTION
## :pencil: Description

Address ruff's `ANN` rule set
* Most errors came from `__init__` methods that did not have a `--> None` annotation
* A handful of errors came from external methods whose return type was not annotated.
  I fixed those based on each method's documented return type
* One error was a `:Any` type annotation. I don't know whether that `Any` can be improved, so I disabled that particular line

## :gear: Work Item

#57 (one TODO item)

## :movie_camera: Demo
Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.
