### PR TITLE
Address ruff FBT ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ select = [
     "ASYNC",
     "S",
     "BLE",
-    # "FBT", # 44
+    "FBT",
     # "B", # 11
     "A",
     "COM",

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -181,6 +181,7 @@ def _VersionCallback(value: bool) -> None:
 )
 def EntryPoint(
     ctx: typer.Context,
+    *,
     version: Annotated[
         bool,
         typer.Option(

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -220,14 +220,18 @@ def EntryPoint(
         ),
     ] = [],
     all_warnings_as_error: Annotated[
-        bool, typer.Option("--all-warnings-as-error", help="Treat all warnings as errors.")
+        bool,
+        typer.Option("--all-warnings-as-error", help="Treat all warnings as errors."),
     ] = False,
     ignore_all_warnings: Annotated[
         bool, typer.Option("--ignore-all-warnings", help="Ignore all warnings.")
     ] = False,
     single_threaded: Annotated[
         bool,
-        typer.Option("--single-threaded", help="Do not use multiple threads when evaluating requirements."),
+        typer.Option(
+            "--single-threaded",
+            help="Do not use multiple threads when evaluating requirements.",
+        ),
     ] = False,
     no_resolution: Annotated[
         bool,

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -165,7 +165,7 @@ def _HelpEpilog() -> str:
 
 
 # ----------------------------------------------------------------------
-def _VersionCallback(value: bool) -> None:
+def _VersionCallback(value: bool) -> None:  # noqa: FBT001
     if value:
         sys.stdout.write(f"RepoAuditor v{__version__}\n")
         raise typer.Exit()

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
@@ -17,7 +17,6 @@ class AllowDeletions(ClassicEnableRequirementImpl):
     def __init__(self):
         super(AllowDeletions, self).__init__(
             "AllowDeletions",
-            False,
             "true",
             "Rules applied to everyone including administrators",
             "Allow deletions",
@@ -35,4 +34,5 @@ class AllowDeletions(ClassicEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
@@ -17,7 +17,6 @@ class AllowForcePushes(ClassicEnableRequirementImpl):
     def __init__(self):
         super(AllowForcePushes, self).__init__(
             "AllowForcePushes",
-            False,
             "true",
             "Rules applied to everyone including administrators",
             "Allow force pushes",
@@ -37,4 +36,5 @@ class AllowForcePushes(ClassicEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
@@ -19,7 +19,6 @@ class DismissStalePullRequestApprovals(ClassicEnableRequirementImpl):
     def __init__(self):
         super(DismissStalePullRequestApprovals, self).__init__(
             "DismissStalePullRequestApprovals",
-            True,
             "false",
             "Protect matching branches",
             "Require a pull request before merging -> Dismiss stale pull request approvals when new commits are pushed",
@@ -38,6 +37,7 @@ class DismissStalePullRequestApprovals(ClassicEnableRequirementImpl):
                 <unknown>
                 """
             ),
+            default_value=True,
         )
 
 

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
@@ -17,7 +17,6 @@ class DoNotAllowBypassSettings(ClassicEnableRequirementImpl):
     def __init__(self):
         super(DoNotAllowBypassSettings, self).__init__(
             "DoNotAllowBypassSettings",
-            True,
             "false",
             "Protect matching branches",
             "Do not allow bypassing the above settings",
@@ -41,4 +40,5 @@ class DoNotAllowBypassSettings(ClassicEnableRequirementImpl):
                   underlying instability.
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
@@ -58,7 +58,7 @@ class EnsureStatusChecks(Requirement):
             "disable": (
                 bool,
                 typer.Option(
-                    False,
+                    default=False,
                     help="If set, status checks will not be enforced.",
                 ),
             ),

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
@@ -19,7 +19,6 @@ class ClassicEnableRequirementImpl(EnableRequirementImpl):
     def __init__(
         self,
         name: str,
-        default_value: bool,
         dynamic_arg_name: str,
         github_settings_section: str,
         github_settings_value: str,
@@ -27,12 +26,12 @@ class ClassicEnableRequirementImpl(EnableRequirementImpl):
         rationale: str,
         subject: Optional[str] = None,
         *,
+        default_value: bool,
         requires_explicit_include: bool = False,
         unset_set_terminology: tuple[str, str] = ("unchecked", "checked"),
     ) -> None:
         super(ClassicEnableRequirementImpl, self).__init__(
             name,
-            default_value,
             dynamic_arg_name,
             github_settings_value,
             get_configuration_value_func,
@@ -47,6 +46,7 @@ class ClassicEnableRequirementImpl(EnableRequirementImpl):
             ),
             rationale,
             subject,
+            default_value=default_value,
             requires_explicit_include=requires_explicit_include,
             unset_set_terminology=unset_set_terminology,
             missing_value_is_warning=False,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
@@ -19,7 +19,6 @@ class RequireApprovalMostRecentPush(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireApprovalMostRecentPush, self).__init__(
             "RequireApprovalMostRecentPush",
-            True,
             "false",
             "Protect matching branches",
             "Require a pull request before merging -> Require approval of the most recent reviewable push",
@@ -37,6 +36,7 @@ class RequireApprovalMostRecentPush(ClassicEnableRequirementImpl):
                 - You are the only person working on the repository.
                 """,
             ),
+            default_value=True,
         )
 
 

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
@@ -19,7 +19,6 @@ class RequireCodeOwnerReview(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireCodeOwnerReview, self).__init__(
             "RequireCodeOwnerReview",
-            False,
             "true",
             "Protect matching branches",
             "Require a pull request before merging -> Require review from Code Owners",
@@ -41,6 +40,7 @@ class RequireCodeOwnerReview(ClassicEnableRequirementImpl):
                   catch common problems before they are introduced into the code base.
                 """,
             ),
+            default_value=False,
         )
 
 

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
@@ -17,11 +17,12 @@ class RequireConversationResolution(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireConversationResolution, self).__init__(
             "RequireConversationResolution",
-            True,
             "false",
             "Protect matching branches",
             "Require conversation resolution before merging",
-            lambda data: data["branch_protection_data"]["required_conversation_resolution"]["enabled"],
+            lambda data: data["branch_protection_data"][
+                "required_conversation_resolution"
+            ]["enabled"],
             textwrap.dedent(
                 """\
                 The default behavior is to require conversation resolution before merging a pull request.
@@ -36,4 +37,5 @@ class RequireConversationResolution(ClassicEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
@@ -20,9 +20,7 @@ class RequireConversationResolution(ClassicEnableRequirementImpl):
             "false",
             "Protect matching branches",
             "Require conversation resolution before merging",
-            lambda data: data["branch_protection_data"][
-                "required_conversation_resolution"
-            ]["enabled"],
+            lambda data: data["branch_protection_data"]["required_conversation_resolution"]["enabled"],
             textwrap.dedent(
                 """\
                 The default behavior is to require conversation resolution before merging a pull request.

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
@@ -20,9 +20,7 @@ class RequireLinearHistory(ClassicEnableRequirementImpl):
             "true",
             "Protect matching branches",
             "Require linear history",
-            lambda data: data["branch_protection_data"]["required_linear_history"][
-                "enabled"
-            ],
+            lambda data: data["branch_protection_data"]["required_linear_history"]["enabled"],
             textwrap.dedent(
                 """\
                 The default behavior is to not require a linear history as this option is disabled when rebase

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
@@ -17,11 +17,12 @@ class RequireLinearHistory(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireLinearHistory, self).__init__(
             "RequireLinearHistory",
-            False,
             "true",
             "Protect matching branches",
             "Require linear history",
-            lambda data: data["branch_protection_data"]["required_linear_history"]["enabled"],
+            lambda data: data["branch_protection_data"]["required_linear_history"][
+                "enabled"
+            ],
             textwrap.dedent(
                 """\
                 The default behavior is to not require a linear history as this option is disabled when rebase
@@ -37,4 +38,5 @@ class RequireLinearHistory(ClassicEnableRequirementImpl):
                 - You have enabled rebase merging or squash merging
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
@@ -20,8 +20,7 @@ class RequirePullRequests(ClassicEnableRequirementImpl):
             "false",
             "Protect matching branches",
             "Require a pull request before merging",
-            lambda data: "required_pull_request_reviews"
-            in data["branch_protection_data"],
+            lambda data: "required_pull_request_reviews" in data["branch_protection_data"],
             textwrap.dedent(
                 """\
                 The default behavior is to require pull requests before merging.

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
@@ -17,11 +17,11 @@ class RequirePullRequests(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequirePullRequests, self).__init__(
             "RequirePullRequests",
-            True,
             "false",
             "Protect matching branches",
             "Require a pull request before merging",
-            lambda data: "required_pull_request_reviews" in data["branch_protection_data"],
+            lambda data: "required_pull_request_reviews"
+            in data["branch_protection_data"],
             textwrap.dedent(
                 """\
                 The default behavior is to require pull requests before merging.
@@ -36,4 +36,5 @@ class RequirePullRequests(ClassicEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
@@ -20,9 +20,7 @@ class RequireSignedCommits(ClassicEnableRequirementImpl):
             "false",
             "Protect matching branches",
             "Require signed commits",
-            lambda data: data["branch_protection_data"]["required_signatures"][
-                "enabled"
-            ],
+            lambda data: data["branch_protection_data"]["required_signatures"]["enabled"],
             textwrap.dedent(
                 """\
                 The default behavior is to require signed commits. Note that this setting does not work with

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
@@ -17,11 +17,12 @@ class RequireSignedCommits(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireSignedCommits, self).__init__(
             "RequireSignedCommits",
-            True,
             "false",
             "Protect matching branches",
             "Require signed commits",
-            lambda data: data["branch_protection_data"]["required_signatures"]["enabled"],
+            lambda data: data["branch_protection_data"]["required_signatures"][
+                "enabled"
+            ],
             textwrap.dedent(
                 """\
                 The default behavior is to require signed commits. Note that this setting does not work with
@@ -36,4 +37,5 @@ class RequireSignedCommits(ClassicEnableRequirementImpl):
                 - You have enabled rebase merging or squash merging.
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
@@ -17,7 +17,6 @@ class RequireStatusChecksToPass(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireStatusChecksToPass, self).__init__(
             "RequireStatusChecksToPass",
-            True,
             "false",
             "Protect matching branches",
             "Require status checks to pass before merging",
@@ -35,4 +34,5 @@ class RequireStatusChecksToPass(ClassicEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
@@ -19,7 +19,6 @@ class RequireUpToDateBranches(ClassicEnableRequirementImpl):
     def __init__(self):
         super(RequireUpToDateBranches, self).__init__(
             "RequireUpToDateBranches",
-            True,
             "false",
             "Protect matching branches",
             "Require status checks to pass before merging -> Require branches to be up to date before merging",
@@ -39,6 +38,7 @@ class RequireUpToDateBranches(ClassicEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
         )
 
 

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
@@ -58,7 +58,7 @@ class Protected(Requirement):
             "false": (
                 bool,
                 typer.Option(
-                    False,
+                    default=False,
                     help="Allow an unprotected mainline branch.",
                 ),
             ),

--- a/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
@@ -26,7 +26,6 @@ class EnableRequirementImpl(Requirement):
     def __init__(
         self,
         name: str,
-        default_value: bool,
         dynamic_arg_name: str,
         github_settings_value: str,
         get_configuration_value_func: Callable[[dict[str, Any]], Optional[bool]],
@@ -34,6 +33,7 @@ class EnableRequirementImpl(Requirement):
         rationale: str,
         subject: Optional[str] = None,
         *,
+        default_value: bool,
         requires_explicit_include: bool = False,
         unset_set_terminology: tuple[str, str] = ("unchecked", "checked"),
         missing_value_is_warning: bool = True,

--- a/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
@@ -66,7 +66,7 @@ class EnableRequirementImpl(Requirement):
             self.dynamic_arg_name: (
                 bool,
                 typer.Option(
-                    False,
+                    default=False,
                     help=f"Ensures that the value for {self.github_settings_value} is set to {not self.default_value}.",
                 ),
             ),

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
@@ -17,7 +17,6 @@ class AutoMerge(StandardEnableRequirementImpl):
     def __init__(self):
         super(AutoMerge, self).__init__(
             "AutoMerge",
-            True,
             "false",
             "settings",
             "Pull Requests",
@@ -36,4 +35,5 @@ class AutoMerge(StandardEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
@@ -17,7 +17,6 @@ class DeleteHeadBranches(StandardEnableRequirementImpl):
     def __init__(self):
         super(DeleteHeadBranches, self).__init__(
             "DeleteHeadBranches",
-            True,
             "false",
             "settings",
             "Pull Requests",
@@ -38,4 +37,5 @@ class DeleteHeadBranches(StandardEnableRequirementImpl):
                   includes cherry-picked changes from the release branch).
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
@@ -19,7 +19,6 @@ class DependabotSecurityUpdates(StandardEnableRequirementImpl):
     def __init__(self):
         super(DependabotSecurityUpdates, self).__init__(
             "DependabotSecurityUpdates",
-            True,
             "false",
             "settings/security_analysis",
             "Dependabot",
@@ -39,6 +38,7 @@ class DependabotSecurityUpdates(StandardEnableRequirementImpl):
                 - A manual test pass is required before changes can be deployed.
                 """,
             ),
+            default_value=True,
             unset_set_terminology=("disabled", "enabled"),
         )
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
@@ -58,7 +58,7 @@ class Description(Requirement):
             "allow-empty": (
                 bool,
                 typer.Option(
-                    False,
+                    default=False,
                     help="Allow an empty repository description.",
                 ),
             ),

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
@@ -19,7 +19,6 @@ class StandardEnableRequirementImpl(EnableRequirementImpl):
     def __init__(
         self,
         name: str,
-        default_value: bool,
         dynamic_arg_name: str,
         github_settings_url_suffix: str,
         github_settings_section: str,
@@ -28,13 +27,13 @@ class StandardEnableRequirementImpl(EnableRequirementImpl):
         rationale: str,
         subject: Optional[str] = None,
         *,
+        default_value: bool,
         requires_explicit_include: bool = False,
         unset_set_terminology: tuple[str, str] = ("unchecked", "checked"),
         missing_value_is_warning: bool = True,
     ) -> None:
         super(StandardEnableRequirementImpl, self).__init__(
             name,
-            default_value,
             dynamic_arg_name,
             github_settings_value,
             get_configuration_value_func,
@@ -47,6 +46,7 @@ class StandardEnableRequirementImpl(EnableRequirementImpl):
             ),
             rationale,
             subject,
+            default_value=default_value,
             requires_explicit_include=requires_explicit_include,
             unset_set_terminology=unset_set_terminology,
             missing_value_is_warning=missing_value_is_warning,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
@@ -17,7 +17,6 @@ class MergeCommit(StandardEnableRequirementImpl):
     def __init__(self):
         super(MergeCommit, self).__init__(
             "MergeCommit",
-            True,
             "false",
             "settings",
             "Pull Requests",
@@ -36,4 +35,5 @@ class MergeCommit(StandardEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
@@ -57,7 +57,7 @@ class Private(Requirement):
             "true": (
                 bool,
                 typer.Option(
-                    False,
+                    default=False,
                     help="Ensures that the repository's visibility is set to private.",
                 ),
             ),

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
@@ -17,7 +17,6 @@ class RebaseMergeCommit(StandardEnableRequirementImpl):
     def __init__(self):
         super(RebaseMergeCommit, self).__init__(
             "RebaseMergeCommit",
-            False,
             "true",
             "settings",
             "Pull Requests",
@@ -38,4 +37,5 @@ class RebaseMergeCommit(StandardEnableRequirementImpl):
                   pull request process can last for an extended period of time.
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -46,12 +46,7 @@ class SecretScanning(StandardEnableRequirementImpl):
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 def _GetValue(data: dict[str, Any]) -> Optional[bool]:
-    result = (
-        data["standard"]
-        .get("security_and_analysis", {})
-        .get("secret_scanning", {})
-        .get("status", None)
-    )
+    result = data["standard"].get("security_and_analysis", {}).get("secret_scanning", {}).get("status", None)
 
     if result is None:
         return None

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -19,7 +19,6 @@ class SecretScanning(StandardEnableRequirementImpl):
     def __init__(self):
         super(SecretScanning, self).__init__(
             "SecretScanning",
-            True,
             "false",
             "settings/security_analysis",
             "Secret scanning",
@@ -38,6 +37,7 @@ class SecretScanning(StandardEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
             unset_set_terminology=("disabled", "enabled"),
         )
 
@@ -46,7 +46,12 @@ class SecretScanning(StandardEnableRequirementImpl):
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 def _GetValue(data: dict[str, Any]) -> Optional[bool]:
-    result = data["standard"].get("security_and_analysis", {}).get("secret_scanning", {}).get("status", None)
+    result = (
+        data["standard"]
+        .get("security_and_analysis", {})
+        .get("secret_scanning", {})
+        .get("status", None)
+    )
 
     if result is None:
         return None

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -19,7 +19,6 @@ class SecretScanningPushProtection(StandardEnableRequirementImpl):
     def __init__(self):
         super(SecretScanningPushProtection, self).__init__(
             "SecretScanningPushProtection",
-            True,
             "false",
             "settings/security_analysis",
             "Secret scanning",
@@ -38,6 +37,7 @@ class SecretScanningPushProtection(StandardEnableRequirementImpl):
                 <unknown>
                 """,
             ),
+            default_value=True,
             unset_set_terminology=("disabled", "enabled"),
         )
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -17,7 +17,6 @@ class SquashCommitMerge(StandardEnableRequirementImpl):
     def __init__(self):
         super(SquashCommitMerge, self).__init__(
             "SquashCommitMerge",
-            False,
             "true",
             "settings",
             "Pull Requests",
@@ -37,4 +36,5 @@ class SquashCommitMerge(StandardEnableRequirementImpl):
                 - You want to ensure that single-commit-changes are merged into the mainline branch to simplify the branch's history.
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
@@ -17,7 +17,6 @@ class SuggestUpdatingPullRequestBranches(StandardEnableRequirementImpl):
     def __init__(self):
         super(SuggestUpdatingPullRequestBranches, self).__init__(
             "SuggestUpdatingPullRequestBranches",
-            False,
             "true",
             "settings",
             "Pull Requests",
@@ -38,4 +37,5 @@ class SuggestUpdatingPullRequestBranches(StandardEnableRequirementImpl):
                 - Merge problems more insidious than conflicts are infrequent.
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
@@ -17,7 +17,6 @@ class SupportDiscussions(StandardEnableRequirementImpl):
     def __init__(self):
         super(SupportDiscussions, self).__init__(
             "SupportDiscussions",
-            False,
             "true",
             "settings",
             "Features",
@@ -28,5 +27,6 @@ class SupportDiscussions(StandardEnableRequirementImpl):
                 No rationale for this default.
                 """,
             ),
+            default_value=False,
             subject="Support for Discussions",
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
@@ -17,7 +17,6 @@ class SupportIssues(StandardEnableRequirementImpl):
     def __init__(self):
         super(SupportIssues, self).__init__(
             "SupportIssues",
-            True,
             "false",
             "settings",
             "Features",
@@ -28,5 +27,6 @@ class SupportIssues(StandardEnableRequirementImpl):
                 No rationale for this default.
                 """,
             ),
+            default_value=True,
             subject="Support for Issues",
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
@@ -17,7 +17,6 @@ class SupportProjects(StandardEnableRequirementImpl):
     def __init__(self):
         super(SupportProjects, self).__init__(
             "SupportProjects",
-            True,
             "false",
             "settings",
             "Features",
@@ -28,5 +27,6 @@ class SupportProjects(StandardEnableRequirementImpl):
                 No rationale for this default.
                 """,
             ),
+            default_value=True,
             subject="Support for Projects",
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
@@ -17,7 +17,6 @@ class SupportWikis(StandardEnableRequirementImpl):
     def __init__(self):
         super(SupportWikis, self).__init__(
             "SupportWikis",
-            True,
             "false",
             "settings",
             "Features",
@@ -29,4 +28,5 @@ class SupportWikis(StandardEnableRequirementImpl):
                 """,
             ),
             subject="Support for Wikis",
+            default_value=True,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
@@ -17,7 +17,6 @@ class TemplateRepository(StandardEnableRequirementImpl):
     def __init__(self):
         super(TemplateRepository, self).__init__(
             "TemplateRepository",
-            False,
             "true",
             "settings",
             "General",
@@ -36,4 +35,5 @@ class TemplateRepository(StandardEnableRequirementImpl):
                 - Your repository is a template repository.
                 """,
             ),
+            default_value=False,
         )

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
@@ -17,7 +17,6 @@ class WebCommitSignoff(StandardEnableRequirementImpl):
     def __init__(self):
         super(WebCommitSignoff, self).__init__(
             "WebCommitSignoff",
-            True,
             "false",
             "settings",
             "General",
@@ -37,4 +36,5 @@ class WebCommitSignoff(StandardEnableRequirementImpl):
                   the standard validation process.
                 """,
             ),
+            default_value=True,
         )


### PR DESCRIPTION
## :pencil: Description

Address ruff's FBT ruleset.

Multiple FBT-related errors came from boilerplate code for low-level checks that used boolean-valued positional arguments.
I fixed those by
* making `default_value` a keyword argument in the parent classes' constructors
* explicitly passing `default_value=<...>` in the child class constructor

This raises the question of whether we should / want to name all arguments in child classes' constructors.
* Pro: it would make the code more uniform and more readable
* Con: it's a lot of boilerplate changes

## :gear: Work Item

#57 

## :movie_camera: Demo
Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.
