### PR TITLE
add step to run pyenv rehash to update PATH if using pyenv

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,7 @@
 | 2. Install [uv](https://github.com/astral-sh/uv). | `curl -LsSf https://astral.sh/uv/install.sh \| sh` on macOS and Linux or <br/>`powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 \| iex"` on Windows | https://docs.astral.sh |
 | 3. Install dependencies. | `uv sync` | https://docs.astral.sh/uv/concepts/projects/sync |
 | 4. Install [pre-commit](https://pre-commit.com/) hooks | `uv run pre-commit install` | https://pre-commit.com/#1-install-pre-commit |
+| 5. (Optional) Update PATH if using `pyenv` | `pyenv rehash` | |
 
 ## Development Activities
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ TODO: Complete this section
 
 <!-- Content below this delimiter will be copied to the generated README.md file. DO NOT REMOVE THIS COMMENT, as it will cause regeneration to fail. -->
 
+Once installed, you can invoke the following to get a list of command line options.
+```shell
+repo_auditor --help
+```
+
+The most common use case would be to audit a GitHub repository.
+In order to allow `RepoAuditor` to read the repository, you first need to generate a Personal Access Token or PAT.
+Please refer to the [GitHub documentation on Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to generate a `Fine-grained PAT` for use.
+After obtaining the PAT, you can save it in a file (e.g. `PAT`) which `RepoAuditor` can read on operation.
+
+With the PAT file, you can now run `RepoAuditor` on your GitHub repository.
+As an example, we will use the [python-helloworld](https://github.com/dbarnett/python-helloworld) repo.
+
+**NOTE** You need to fork the repository since your default PAT only has access to repos under your account.
+
+To run `RepoAuditor`, we can enter the following in the command-line:
+```shell
+repo_auditor --include GitHub --GitHub-url https://github.com/<username>/python-helloworld --GitHub-pat PAT
+```
+
+`RepoAuditor` will generate a series of messages describing all the issues in the repository, along with the rationale behind them and the steps for resolution.
+
 ## Installation
 
 | Installation Method | Command |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Artifacts are signed and validated using [py-minisign](https://github.com/x13a/p
 
 To verify that an artifact is valid, visit [the latest release](https://github.com/gt-sse-center/RepoAuditor/releases/latest) and download the `.minisign` signature file that corresponds to the artifact, then run the following command, replacing `<filename>` with the name of the artifact to be verified:
 
-`uv run --with py-minisign python -c "import minisign; minisign.PublicKey.from_file('minisign_key.pub').verify_file('<filename>')"`
+```shell
+uv run --with py-minisign python -c "import minisign; minisign.PublicKey.from_file('minisign_key.pub').verify_file('<filename>')"
+```
 
 ## Development
 Please visit [Contributing](https://github.com/gt-sse-center/RepoAuditor/blob/main/CONTRIBUTING.md) and [Development](https://github.com/gt-sse-center/RepoAuditor/blob/main/DEVELOPMENT.md) for information on contributing to this project.


### PR DESCRIPTION
## :pencil: Description

Update the How To Use section of the README.

Also added a note on updating the `pyenv` paths in case pyenv is used to manage the python versions, as well as converting commands to fenced blocks so that a copy-to-clipboard button is automatically generated.

## :gear: Work Item

Fixes #40

## :movie_camera: Demo
N/A