### PR TITLE
Address ruff TRY ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ select = [
     # "UP", # 100
     "FURB",
     "RUF",
-    # "TRY", # 16
+    "TRY",
 
 ]
 

--- a/src/RepoAuditor/CommandLineProcessor.py
+++ b/src/RepoAuditor/CommandLineProcessor.py
@@ -70,13 +70,13 @@ class CommandLineProcessor:
 
         for module in modules:
             if argument_separator in module.name:
-                msg = f"The module name '{module.name}' contains '{argument_separator}'."
-                raise Exception(msg)
+                msg = f"The module name '{module.name}' contains '{argument_separator}', which should be used as an argument separator."
+                raise ValueError(msg)
 
             prev_module = module_map.get(module.name, None)
             if prev_module is not None:
                 msg = f"The module '{module.name}' has already been defined."
-                raise Exception(msg)
+                raise ValueError(msg)
 
             module_map[module.name] = module
 
@@ -92,7 +92,7 @@ class CommandLineProcessor:
             this_module = module_map.get(parts[0], None)
             if this_module is None:
                 msg = f"'{parts[0]}' is not a recognized module name."
-                raise Exception(msg)
+                raise ValueError(msg)
 
             if len(parts) == 1:
                 included_modules.add(parts[0])
@@ -119,7 +119,7 @@ class CommandLineProcessor:
             this_module = module_map.get(parts[0], None)
             if this_module is None:
                 msg = f"'{parts[0]}' is not a recognized module name."
-                raise Exception(msg)
+                raise ValueError(msg)
 
             if len(parts) == 1:
                 module_map.pop(parts[0])
@@ -173,7 +173,7 @@ class CommandLineProcessor:
 
             if parts[0] not in module_map:
                 msg = f"'{parts[0]}' is not a recognized module name."
-                raise Exception(msg)
+                raise ValueError(msg)
 
             if len(parts) == 2:
                 dynamic_args.setdefault(parts[0], {})[parts[1]] = value

--- a/src/RepoAuditor/Module.py
+++ b/src/RepoAuditor/Module.py
@@ -92,7 +92,7 @@ class Module(ABC):
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
         """Returns information about dynamic arguments that the module can consume (often from the command line)."""
 
-        raise Exception("Abstract method")  # pragma: no cover # noqa: EM101
+        raise NotImplementedError("Abstract method")  # pragma: no cover # noqa: EM101
 
     # ----------------------------------------------------------------------
     @abstractmethod
@@ -107,7 +107,7 @@ class Module(ABC):
         exception to indicate that the command line data is invalid.
         """
 
-        raise Exception("Abstract method")  # pragma: no cover # noqa: EM101
+        raise NotImplementedError("Abstract method")  # pragma: no cover # noqa: EM101
 
     # ----------------------------------------------------------------------
     def Evaluate(

--- a/src/RepoAuditor/Plugin.py
+++ b/src/RepoAuditor/Plugin.py
@@ -17,4 +17,4 @@ from .Module import Module
 @pluggy.HookspecMarker(APP_NAME)
 def GetModule() -> Module:
     """Returns a Module"""
-    raise Exception("hookspec")  # pragma: no cover # noqa: EM101
+    raise NotImplementedError("hookspec")  # pragma: no cover # noqa: EM101

--- a/tests/CommandLineProcessor_UnitTest.py
+++ b/tests/CommandLineProcessor_UnitTest.py
@@ -369,7 +369,9 @@ def test_IgnoreAllWarnings():
 def test_ErrorInvalidModuleName():
     with pytest.raises(
         Exception,
-        match=re.escape("The module name 'Invalid-name' contains '-'."),
+        match=re.escape(
+            "The module name 'Invalid-name' contains '-', which should be used as an argument separator."
+        ),
     ):
         CommandLineProcessor.Create(
             lambda *args: {},


### PR DESCRIPTION
## :pencil: Description
Address ruff linter errors from TRY ruleset by using `ValueError` when an exception occurs on a variable, and `NotImplementedError` for abstract methods/functions.

NOTE: This PR is targeted to the `va/ruff-ARG` branch so that when the target branch is merged and deleted, this PR will automatically target `main`.

## :gear: Work Item
#57

## :movie_camera: Demo
Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.
