### PR TITLE
Address ruff UP ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ select = [
     "F",
     "PGH",
     # "PL", # 11
-    # "UP", # 100
+    "UP",
     "FURB",
     "RUF",
     "TRY",
@@ -150,7 +150,9 @@ ignore = [
     "RSE102", # Unnecessary parentheses on raise exception
     "S101", # Use of assert detected
     "TC006", # Add quotes to type expression in `typing.cast()`
+    "UP007", # Use `X | Y` for type annotations
     "UP032", # Use f-string instead of `format` call
+    "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 ]
 
 [tool.ruff.lint.mccabe]

--- a/src/RepoAuditor/ExecuteModules.py
+++ b/src/RepoAuditor/ExecuteModules.py
@@ -11,7 +11,8 @@ import sys
 import textwrap
 
 from dataclasses import dataclass
-from typing import Any, Callable, cast, Optional
+from typing import Any, cast, Optional
+from collections.abc import Callable
 
 from dbrownell_Common import ExecuteTasks  # type: ignore[import-untyped]
 from dbrownell_Common.InflectEx import inflect  # type: ignore[import-untyped]

--- a/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
+++ b/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
@@ -7,7 +7,8 @@
 """Contains functionality to process items in parallel and/or sequentially."""
 
 from enum import auto, Enum
-from typing import Callable, cast, Optional, TypeVar
+from typing import cast, TypeVar, Optional
+from collections.abc import Callable
 
 from dbrownell_Common import ExecuteTasks  # type: ignore[import-untyped]
 from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionQuery.py
@@ -90,7 +90,7 @@ class ClassicBranchProtectionQuery(Query):
 
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(ClassicBranchProtectionQuery, self).__init__(
+        super().__init__(
             "ClassicBranchProtectionQuery",
             ExecutionStyle.Parallel,
             [

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class AllowDeletions(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(AllowDeletions, self).__init__(
+        super().__init__(
             "AllowDeletions",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class AllowForcePushes(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(AllowForcePushes, self).__init__(
+        super().__init__(
             "AllowForcePushes",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
@@ -17,7 +17,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class DismissStalePullRequestApprovals(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(DismissStalePullRequestApprovals, self).__init__(
+        super().__init__(
             "DismissStalePullRequestApprovals",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class DoNotAllowBypassSettings(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(DoNotAllowBypassSettings, self).__init__(
+        super().__init__(
             "DoNotAllowBypassSettings",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
@@ -21,7 +21,7 @@ from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
 class EnsureStatusChecks(Requirement):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(EnsureStatusChecks, self).__init__(
+        super().__init__(
             "EnsureStatusChecks",
             "Ensure that status checks have been enabled for the branch.",
             ExecutionStyle.Parallel,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
@@ -8,7 +8,8 @@
 
 import textwrap
 
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 from ...Impl.EnableRequirementImpl import EnableRequirementImpl
 
@@ -30,7 +31,7 @@ class ClassicEnableRequirementImpl(EnableRequirementImpl):
         requires_explicit_include: bool = False,
         unset_set_terminology: tuple[str, str] = ("unchecked", "checked"),
     ) -> None:
-        super(ClassicEnableRequirementImpl, self).__init__(
+        super().__init__(
             name,
             default_value,
             dynamic_arg_name,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicValueRequirementImpl.py
@@ -8,7 +8,8 @@
 
 import textwrap
 
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 from ...Impl.ValueRequirementImpl import DoesNotApplyResult, ValueRequirementImpl
 
@@ -46,7 +47,7 @@ class ClassicValueRequirementImpl(ValueRequirementImpl):
                 """,
             )
 
-        super(ClassicValueRequirementImpl, self).__init__(
+        super().__init__(
             name,
             default_value,
             github_settings_value,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
@@ -17,7 +17,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireApprovalMostRecentPush(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireApprovalMostRecentPush, self).__init__(
+        super().__init__(
             "RequireApprovalMostRecentPush",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
@@ -17,7 +17,7 @@ from .Impl.ClassicValueRequirementImpl import ClassicValueRequirementImpl, DoesN
 class RequireApprovals(ClassicValueRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireApprovals, self).__init__(
+        super().__init__(
             "RequireApprovals",
             "1",
             "Protect matching branches",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
@@ -8,7 +8,7 @@
 
 import textwrap
 
-from typing import Any
+from typing import Any, Optional
 
 from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
@@ -17,7 +17,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireCodeOwnerReview(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireCodeOwnerReview, self).__init__(
+        super().__init__(
             "RequireCodeOwnerReview",
             False,
             "true",
@@ -49,7 +49,7 @@ class RequireCodeOwnerReview(ClassicEnableRequirementImpl):
 # ----------------------------------------------------------------------
 def _GetValue(
     data: dict[str, Any],
-) -> bool | None:
+) -> Optional[bool]:
     settings = data["branch_protection_data"].get("required_pull_request_reviews", None)
     if settings is None:
         return None

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireConversationResolution(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireConversationResolution, self).__init__(
+        super().__init__(
             "RequireConversationResolution",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireLinearHistory(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireLinearHistory, self).__init__(
+        super().__init__(
             "RequireLinearHistory",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequirePullRequests(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequirePullRequests, self).__init__(
+        super().__init__(
             "RequirePullRequests",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireSignedCommits(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireSignedCommits, self).__init__(
+        super().__init__(
             "RequireSignedCommits",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
@@ -15,7 +15,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireStatusChecksToPass(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireStatusChecksToPass, self).__init__(
+        super().__init__(
             "RequireStatusChecksToPass",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
@@ -17,7 +17,7 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 class RequireUpToDateBranches(ClassicEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RequireUpToDateBranches, self).__init__(
+        super().__init__(
             "RequireUpToDateBranches",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQuery.py
@@ -21,7 +21,7 @@ class DefaultBranchQuery(Query):
 
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(DefaultBranchQuery, self).__init__(
+        super().__init__(
             "DefaultBranchQuery",
             ExecutionStyle.Parallel,
             [

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
@@ -25,7 +25,7 @@ class Protected(Requirement):
     def __init__(self) -> None:
         # Note that protected is set for the branch when creating a branch ruleset or a classic
         # branch protection rule.
-        super(Protected, self).__init__(
+        super().__init__(
             "Protected",
             "Ensures that the mainline branch is protected.",
             ExecutionStyle.Parallel,

--- a/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
@@ -6,7 +6,8 @@
 # -------------------------------------------------------------------------------
 """Contains the EnableRequirementImpl object"""
 
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 import typer
 
@@ -43,7 +44,7 @@ class EnableRequirementImpl(Requirement):
         if subject is None:
             subject = github_settings_value
 
-        super(EnableRequirementImpl, self).__init__(
+        super().__init__(
             name,
             f"Validates that {subject} is set to the expected value.",
             ExecutionStyle.Parallel,

--- a/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
@@ -7,7 +7,8 @@
 """Contains the ValueRequirementImpl object"""
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 import typer
 
@@ -53,7 +54,7 @@ class ValueRequirementImpl(Requirement):
         if subject is None:
             subject = github_settings_value
 
-        super(ValueRequirementImpl, self).__init__(
+        super().__init__(
             name,
             f"Validates that {subject} is set to the expected value.",
             ExecutionStyle.Parallel,

--- a/src/RepoAuditor/Plugins/GitHub/Module.py
+++ b/src/RepoAuditor/Plugins/GitHub/Module.py
@@ -27,7 +27,7 @@ from .StandardQuery import StandardQuery
 class GitHubModule(Module):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(GitHubModule, self).__init__(
+        super().__init__(
             "GitHub",
             "Validates GitHub configuration settings.",
             ExecutionStyle.Parallel,
@@ -90,7 +90,7 @@ class _GitHubSession(requests.Session):
         *args,
         **kwargs,
     ) -> None:
-        super(_GitHubSession, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.headers.update(
             {
@@ -145,7 +145,7 @@ class _GitHubSession(requests.Session):
         if url and not url.startswith("/"):
             url = f"/{url}"
 
-        return super(_GitHubSession, self).request(
+        return super().request(
             method,
             f"{self.api_url}{url}",
             *args,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
@@ -200,7 +200,7 @@ class StandardQuery(Query):
 
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(StandardQuery, self).__init__(
+        super().__init__(
             "StandardQuery",
             ExecutionStyle.Parallel,
             [

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class AutoMerge(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(AutoMerge, self).__init__(
+        super().__init__(
             "AutoMerge",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
@@ -15,7 +15,7 @@ from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
 class DefaultBranch(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(DefaultBranch, self).__init__(
+        super().__init__(
             "DefaultBranch",
             "main",
             "settings",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class DeleteHeadBranches(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(DeleteHeadBranches, self).__init__(
+        super().__init__(
             "DeleteHeadBranches",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
@@ -17,7 +17,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class DependabotSecurityUpdates(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(DependabotSecurityUpdates, self).__init__(
+        super().__init__(
             "DependabotSecurityUpdates",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
@@ -24,7 +24,7 @@ from ..Impl.Common import CreateIncompleteDataResult
 class Description(Requirement):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(Description, self).__init__(
+        super().__init__(
             "Description",
             "Validates a repository's description.",
             ExecutionStyle.Parallel,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
@@ -8,7 +8,8 @@
 
 import textwrap
 
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 from ...Impl.EnableRequirementImpl import EnableRequirementImpl
 
@@ -32,7 +33,7 @@ class StandardEnableRequirementImpl(EnableRequirementImpl):
         unset_set_terminology: tuple[str, str] = ("unchecked", "checked"),
         missing_value_is_warning: bool = True,
     ) -> None:
-        super(StandardEnableRequirementImpl, self).__init__(
+        super().__init__(
             name,
             default_value,
             dynamic_arg_name,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardValueRequirementImpl.py
@@ -8,7 +8,8 @@
 
 import textwrap
 
-from typing import Any, Callable, Optional
+from typing import Any, Optional
+from collections.abc import Callable
 
 from ...Impl.ValueRequirementImpl import DoesNotApplyResult, ValueRequirementImpl
 
@@ -48,7 +49,7 @@ class StandardValueRequirementImpl(
                 """,
             )
 
-        super(StandardValueRequirementImpl, self).__init__(
+        super().__init__(
             name,
             default_value,
             github_settings_value,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
@@ -17,7 +17,7 @@ from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
 class License(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(License, self).__init__(
+        super().__init__(
             "License",
             "MIT License",
             "settings",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class MergeCommit(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(MergeCommit, self).__init__(
+        super().__init__(
             "MergeCommit",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
@@ -17,7 +17,7 @@ from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValue
 class MergeCommitMessage(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(MergeCommitMessage, self).__init__(
+        super().__init__(
             "MergeCommitMessage",
             "BLANK",
             "settings",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
@@ -23,7 +23,7 @@ from ..Impl.Common import CreateIncompleteDataResult
 class Private(Requirement):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(Private, self).__init__(
+        super().__init__(
             "Private",
             "Validates that the repository is set to the expected visibility.",
             ExecutionStyle.Parallel,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class RebaseMergeCommit(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(RebaseMergeCommit, self).__init__(
+        super().__init__(
             "RebaseMergeCommit",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -17,7 +17,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SecretScanning(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SecretScanning, self).__init__(
+        super().__init__(
             "SecretScanning",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -17,7 +17,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SecretScanningPushProtection(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SecretScanningPushProtection, self).__init__(
+        super().__init__(
             "SecretScanningPushProtection",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SquashCommitMerge(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SquashCommitMerge, self).__init__(
+        super().__init__(
             "SquashCommitMerge",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
@@ -17,7 +17,7 @@ from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValue
 class SquashMergeCommitMessage(StandardValueRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SquashMergeCommitMessage, self).__init__(
+        super().__init__(
             "SquashMergeCommitMessage",
             "COMMIT_MESSAGES",
             "settings",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SuggestUpdatingPullRequestBranches(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SuggestUpdatingPullRequestBranches, self).__init__(
+        super().__init__(
             "SuggestUpdatingPullRequestBranches",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SupportDiscussions(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SupportDiscussions, self).__init__(
+        super().__init__(
             "SupportDiscussions",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SupportIssues(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SupportIssues, self).__init__(
+        super().__init__(
             "SupportIssues",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SupportProjects(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SupportProjects, self).__init__(
+        super().__init__(
             "SupportProjects",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class SupportWikis(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(SupportWikis, self).__init__(
+        super().__init__(
             "SupportWikis",
             True,
             "false",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class TemplateRepository(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(TemplateRepository, self).__init__(
+        super().__init__(
             "TemplateRepository",
             False,
             "true",

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
@@ -15,7 +15,7 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 class WebCommitSignoff(StandardEnableRequirementImpl):
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
-        super(WebCommitSignoff, self).__init__(
+        super().__init__(
             "WebCommitSignoff",
             True,
             "false",

--- a/src/RepoAuditor/Query.py
+++ b/src/RepoAuditor/Query.py
@@ -10,7 +10,7 @@ import threading
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol, Optional
 
 from .Impl.ParallelSequentialProcessor import ParallelSequentialProcessor
 from .Requirement import EvaluateResult, ExecutionStyle, Requirement

--- a/tests/CommandLineProcessor_UnitTest.py
+++ b/tests/CommandLineProcessor_UnitTest.py
@@ -9,7 +9,7 @@
 import re
 import textwrap
 
-from typing import cast, ClassVar, Optional
+from typing import cast, Optional
 from unittest.mock import patch
 
 import pytest
@@ -37,7 +37,7 @@ class MyModule(Module):
         *,
         requires_explicit_include: bool = False,
     ):
-        super(MyModule, self).__init__(
+        super().__init__(
             name,
             "",
             ExecutionStyle.Sequential,
@@ -66,7 +66,7 @@ class MyModule(Module):
 class MyQuery(Query):
     # ----------------------------------------------------------------------
     def __init__(self):
-        super(MyQuery, self).__init__(
+        super().__init__(
             "MyQuery",
             ExecutionStyle.Sequential,
             [
@@ -94,7 +94,7 @@ class MyRequirement(Requirement):
         requires_explicit_include: bool = False,
         has_dynamic_args: bool = False,
     ):
-        super(MyRequirement, self).__init__(
+        super().__init__(
             name,
             "",
             ExecutionStyle.Sequential,

--- a/tests/ExecuteModules_UnitTest.py
+++ b/tests/ExecuteModules_UnitTest.py
@@ -14,7 +14,6 @@ from typing import cast
 
 import pytest
 
-from dbrownell_Common.Streams.Capabilities import Capabilities
 from dbrownell_Common.Types import override
 from dbrownell_Common.TestHelpers.StreamTestHelpers import (
     GenerateDoneManagerAndContent,
@@ -39,7 +38,7 @@ class MyModule(Module):
         no_initial_data: bool = False,
         **kwargs,
     ) -> None:
-        super(MyModule, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.no_initial_data = no_initial_data
 
     # ----------------------------------------------------------------------
@@ -76,7 +75,7 @@ class MyQuery(Query):
         **kwargs,
     ) -> Optional[dict[str, Any]]:
         if args or kwargs:
-            super(MyQuery, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
         module_data["query_name"] = self.name
         return module_data
@@ -86,7 +85,7 @@ class MyQuery(Query):
 class MyRequirement(Requirement):
     # ----------------------------------------------------------------------
     def __init__(self, result: EvaluateResult, *args) -> None:
-        super(MyRequirement, self).__init__(*args)
+        super().__init__(*args)
 
         self.result = result
 

--- a/tests/Module_UnitTest.py
+++ b/tests/Module_UnitTest.py
@@ -31,7 +31,7 @@ class MyModule(Module):
         produce_data: bool,
         requires_explicit_include: bool = False,
     ) -> None:
-        super(MyModule, self).__init__(
+        super().__init__(
             name,
             description,
             style,
@@ -78,7 +78,7 @@ class MyQuery(Query):
         *,
         produce_data: bool,
     ) -> None:
-        super(MyQuery, self).__init__(name, style, requirements)
+        super().__init__(name, style, requirements)
 
         self.produce_data = produce_data
 
@@ -109,7 +109,7 @@ class MyRequirement(Requirement):
         *,
         requires_explicit_include: bool = False,
     ) -> None:
-        super(MyRequirement, self).__init__(
+        super().__init__(
             name,
             description,
             style,

--- a/tests/Query_UnitTest.py
+++ b/tests/Query_UnitTest.py
@@ -62,7 +62,7 @@ class MyRequirement(Requirement):
         expected_result: EvaluateResult,
         context: Optional[str] = None,
     ) -> None:
-        super(MyRequirement, self).__init__(name, description, style, resolution_template, rationale_template)
+        super().__init__(name, description, style, resolution_template, rationale_template)
 
         self.expected_result = expected_result
         self.context = context

--- a/tests/Requirement_UnitTest.py
+++ b/tests/Requirement_UnitTest.py
@@ -31,7 +31,7 @@ class MyRequirement(Requirement):
         requires_explicit_include: bool = False,
         provide_rationale: bool = True,
     ) -> None:
-        super(MyRequirement, self).__init__(
+        super().__init__(
             name,
             description,
             style,


### PR DESCRIPTION
## :pencil: Description
Address ruff linter errors from UP ruleset by:
- ~~Removing `Optional` in favor of `X | Y`.~~
- Using `Callable` from `collections.abc` since the one from `typing` is deprecated.
- Remove redundant class name in call to `super()`.

NOTE: This PR is targeted to the `va/ruff-TRY` branch so that when the target branch is merged and deleted, this PR will automatically target `main`.

## :gear: Work Item
#57

## :movie_camera: Demo
Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.
