### PR TITLE
Add support for `tox` for local development

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -19,6 +19,7 @@
 | 3. Install dependencies. | `uv sync` | [Astral uv sync docs](https://docs.astral.sh/uv/concepts/projects/sync) |
 | 4. Install [pre-commit](https://pre-commit.com/) hooks | `uv run pre-commit install` | [Install pre-commit](https://pre-commit.com/#1-install-pre-commit) |
 | 5. If you wish to test against an enterprise server, add a remote named `enterprise` with the corresponding URL | E.g. `git remote add enterprise git@github.gatech.edu:sse-center/RepoAuditor.git` | |
+| 6. Install [tox](https://tox.wiki/) with `uv` support | `uv tool install tox --with tox-uv` | https://tox.wiki/ |
 
 ### Setup
 
@@ -119,6 +120,7 @@ Please follow the steps below to complete the configuration.
 | Static Code Analysis | `uv run ruff check` | Validate source code using [ruff](https://github.com/astral-sh/ruff) based on settings in `pyproject.toml`. | :white_check_mark: | :white_check_mark: (via [pre-commit](https://pre-commit.com/)) |
 | Run pre-commit scripts | `uv run pre-commit run` | Run [pre-commit](https://pre-commit.com/) scripts based on settings in `.pre-commit-config.yaml`. | :white_check_mark: | :white_check_mark: |
 | Automated Testing | `uv run pytest` or<br/>`uv run pytest --no-cov` | Run automated tests using [pytest](https://docs.pytest.org/) and extract code coverage using [coverage](https://coverage.readthedocs.io/) based on settings in `pyproject.toml`. | :white_check_mark: | :white_check_mark: |
+| Testing multiple Python versions | `uv tool run tox -p` | Run automated tests using [pytest](https://docs.pytest.org/) across multiple versions of Python as specified in the `pyproject.toml`, in parallel. | :white_check_mark: | |
 | Semantic Version Generation | `uv run python -m AutoGitSemVer.scripts.UpdatePythonVersion ./src/RepoAuditor/__init__.py ./src` | Generate a new [Semantic Version](https://semver.org/) based on git commits using [AutoGitSemVer](https://github.com/davidbrownell/AutoGitSemVer). Version information is stored in `./src/RepoAuditor/__init__.py`. | | :white_check_mark: |
 | Python Package Creation | `uv build` | Create a python package using [uv](https://github.com/astral-sh/uv) based on settings in `pyproject.toml`. Generated packages will be written to `./dist`. | | :white_check_mark: |
 | Sign Artifacts | `uv run --with py-minisign python -c "import minisign; minisign.SecretKey.from_file(<temp_filename>).sign_file(<filename>, trusted_comment='<package_name> v<package_version>', drop_signature=True)` | Signs artifacts using [py-minisign](https://github.com/x13a/py-minisign). Note that the private key is stored as a [GitHub secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). | | :white_check_mark: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,13 @@ max-complexity = 15
 max-args = 10
 max-branches = 20
 max-returns = 20
+
+[tool.tox]
+requires = ["tox>=4.26.0"]
+env_list = ["3.13", "3.12", "3.11", "3.10"]
+
+[tool.tox.env_run_base]
+description = "Run test under {base_python}"
+commands = [["pytest"]]
+allowlist_externals =  ["pytest"]
+runner = "uv-venv-lock-runner"


### PR DESCRIPTION
## :pencil: Description
[tox](https://tox.wiki/) is a popular tool for automating python unit testing in various different python environments.

As I discovered in #79, we are not locally testing for python versions beyond 3.13 (at the time of writing), so having `tox` hooked up to `uv` will allow us to test multiple versions locally.

The way to do this is simply `uv tool run tox -p` which is detailed in `DEVELOPMENT.md`.

## :gear: Work Item
Part of #84

## :movie_camera: Demo

We can run `tox` in parallel locally, after running `uv run pytest`. 🥳 
<img width="567" alt="image" src="https://github.com/user-attachments/assets/020e1df3-3876-4aa7-9203-53e80df19ada" />