### PR TITLE
Address ruff D ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ select = [
     "E",
     "W",
     "DOC",
-    # "D", # 249
+    "D",
     "F",
     "PGH",
     # "PL", # 11
@@ -142,6 +142,9 @@ ignore = [
     "ANN003", # Missing type annotation for `**kwargs`
     "BLE001", # Do not catch blind exception: `Exception`
     "COM812", # Trailing comma missing
+    "D104", # Missing docstring in public package
+    "D106", # Missing docstring in public nested class
+    "D107", # Missing docstring in `__init__` method
     "D202", # No blank lines allowed after function docstring
     "E501", # Line too long
     "I001", # Import block is un-sorted or un-formatted

--- a/src/RepoAuditor/CommandLineProcessor.py
+++ b/src/RepoAuditor/CommandLineProcessor.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the CommandLineProcessor object"""
+"""Contains the CommandLineProcessor object."""
 
 from dataclasses import dataclass, field
 from typing import Any, Protocol
@@ -17,7 +17,8 @@ from .ExecuteModules import Execute, Module, ModuleInfo
 # ----------------------------------------------------------------------
 @dataclass(frozen=True)
 class CommandLineProcessor:
-    """\
+    """Class for processing command line arguments and invoking the appropriate modules.
+
     Object that makes it easy to process command line arguments and invoke ExecuteModules.Execute
     in a testable way.
     """
@@ -28,7 +29,7 @@ class CommandLineProcessor:
     # |
     # ----------------------------------------------------------------------
     class GetDynamicArgsFunc(Protocol):
-        def __call__(
+        def __call__(  # noqa: D102
             self,
             dynamic_arg_definitions: dict[
                 str, Any
@@ -65,6 +66,7 @@ class CommandLineProcessor:
         single_threaded: bool = False,
         argument_separator: str = "-",
     ) -> "CommandLineProcessor":
+        """Factor method to construct a CommandLineProcessor object."""
         # Convert modules into a lookup map
         module_map: dict[str, Module] = {}
 
@@ -199,7 +201,7 @@ class CommandLineProcessor:
         )
 
     # ----------------------------------------------------------------------
-    def __call__(
+    def __call__(  # noqa: D102
         self,
         dm: DoneManager,
     ) -> list[list[Module.EvaluateInfo]]:

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -33,8 +33,11 @@ ARGUMENT_SEPARATOR = "-"
 
 # ----------------------------------------------------------------------
 class NaturalOrderGrouper(TyperGroup):
+    """Group commands in natural order."""
+
     # ----------------------------------------------------------------------
     def list_commands(self, *args, **kwargs) -> list[str]:  # noqa: ARG002
+        """Return a list of all the commands, to be sorted in a natural ordering."""
         return self.commands.keys()
 
 
@@ -257,6 +260,7 @@ def EntryPoint(
         ),
     ] = False,
 ) -> None:
+    """Entry point for the command line interface."""
     with DoneManager.CreateCommandLine(
         sys.stdout,
         flags=DoneManagerFlags.Create(verbose=verbose, debug=debug),

--- a/src/RepoAuditor/ExecuteModules.py
+++ b/src/RepoAuditor/ExecuteModules.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains functionality to execute multiple Modules"""
+"""Contains functionality to execute multiple Modules."""
 
 import itertools
 import sys
@@ -34,6 +34,8 @@ from .Module import EvaluateResult, ExecutionStyle, Module, OnStatusFunc
 # ----------------------------------------------------------------------
 @dataclass(frozen=True)
 class ModuleInfo:
+    """Information about a Module."""
+
     module: Module
     dynamic_args: dict[str, Any]
     requirement_args: dict[str, Any]
@@ -52,6 +54,7 @@ def Execute(
     *,
     single_threaded: bool = False,
 ) -> list[list[Module.EvaluateInfo]]:
+    """Execute the modules in parallel and/or sequentially."""
     if not module_infos:
         dm.WriteWarning("There are no modules to process.\n")
         return []
@@ -266,6 +269,7 @@ def DisplayResults(
     display_rationale: bool,
     panel_width: Optional[int] = None,
 ) -> None:
+    """Display the results of executing the modules."""
     for results in all_results:
         assert results
         module = results[0].module

--- a/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
+++ b/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
@@ -35,6 +35,7 @@ def ParallelSequentialProcessor(
     *,
     max_num_threads: Optional[int] = None,
 ) -> list[OutputType]:
+    """Process a list of items in parallel and/or sequentially."""
     if dm is None:
         with DoneManager.Create(StreamDecorator(None), "", line_prefix="") as dm:
             return _Impl(

--- a/src/RepoAuditor/Module.py
+++ b/src/RepoAuditor/Module.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the Module object and types used in its definition"""
+"""Contains the Module object and types used in its definition."""
 
 import threading
 
@@ -55,6 +55,7 @@ class Module(ABC):
 
     # ----------------------------------------------------------------------
     def GetNumRequirements(self) -> int:
+        """Get the total number of requirements across all queries."""
         return sum(len(query.requirements) for query in self.queries)
 
     # ----------------------------------------------------------------------
@@ -63,6 +64,7 @@ class Module(ABC):
         included_names: set[str],
         excluded_names: set[str],
     ) -> None:
+        """Process the requirements to remove invalid requirements and queries."""
         query_index = 0
 
         while query_index < len(self.queries):
@@ -90,7 +92,7 @@ class Module(ABC):
     # ----------------------------------------------------------------------
     @abstractmethod
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
-        """Returns information about dynamic arguments that the module can consume (often from the command line)."""
+        """Return information about dynamic arguments that the module can consume (often from the command line)."""
 
         raise NotImplementedError("Abstract method")  # pragma: no cover # noqa: EM101
 
@@ -100,8 +102,7 @@ class Module(ABC):
         self,
         dynamic_args: dict[str, Any],
     ) -> Optional[dict[str, Any]]:
-        """\
-        Augments data beyond data initially encountered (for example, on the command line).
+        """Augments data beyond data initially encountered (for example, on the command line).
 
         Return None to indicate that the Module cannot be evaluated. Raise an
         exception to indicate that the command line data is invalid.
@@ -118,6 +119,7 @@ class Module(ABC):
         *,
         max_num_threads: Optional[int] = None,
     ) -> list[list["Module.EvaluateInfo"]]:
+        """Evaluate the module using the module data and requirement data."""
         status_info = StatusInfo()
         status_info_lock = threading.Lock()
 

--- a/src/RepoAuditor/Plugin.py
+++ b/src/RepoAuditor/Plugin.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the interface that Plugins must implement"""
+"""Contains the interface that Plugins must implement."""
 
 import pluggy
 
@@ -16,5 +16,5 @@ from .Module import Module
 # ----------------------------------------------------------------------
 @pluggy.HookspecMarker(APP_NAME)
 def GetModule() -> Module:
-    """Returns a Module"""
+    """Return a Module."""
     raise NotImplementedError("hookspec")  # pragma: no cover # noqa: EM101

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionQuery.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the ClassicBranchProtection object"""
+"""Contains the ClassicBranchProtection object."""
 
 from typing import Any, Optional
 
@@ -117,6 +117,7 @@ class ClassicBranchProtectionQuery(Query):
         self,
         module_data: dict[str, Any],
     ) -> Optional[dict[str, Any]]:
+        """Get the data from an API session."""
         branch = module_data.get("branch")
         if branch is None:
             # Get the default branch name

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the AllowDeletions object"""
+"""Contains the AllowDeletions object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class AllowDeletions(ClassicEnableRequirementImpl):
+    """Allow deletion of the mainline branch."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the AllowForcePushes object"""
+"""Contains the AllowForcePushes object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class AllowForcePushes(ClassicEnableRequirementImpl):
+    """Allow force pushes to the mainline branch."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the DismissStalePullRequestApprovals object"""
+"""Contains the DismissStalePullRequestApprovals object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class DismissStalePullRequestApprovals(ClassicEnableRequirementImpl):
+    """Dismiss stale pull request approvals when new commits are pushed."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the AllowBypassSettings object"""
+"""Contains the AllowBypassSettings object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class DoNotAllowBypassSettings(ClassicEnableRequirementImpl):
+    """Do not allow bypassing settings."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the EnsureStatusChecks object"""
+"""Contains the EnsureStatusChecks object."""
 
 import textwrap
 
@@ -19,6 +19,8 @@ from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
 
 # ----------------------------------------------------------------------
 class EnsureStatusChecks(Requirement):
+    """Ensure that status checks have been enabled for the branch."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(
@@ -54,6 +56,7 @@ class EnsureStatusChecks(Requirement):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             "disable": (
                 bool,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the ClassicEnableRequirementImpl object"""
+"""Contains the ClassicEnableRequirementImpl object."""
 
 import textwrap
 
@@ -16,6 +16,8 @@ from ...Impl.EnableRequirementImpl import EnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class ClassicEnableRequirementImpl(EnableRequirementImpl):
+    """Implementation of a requirement that checks a classical setting is enabled."""
+
     # ----------------------------------------------------------------------
     def __init__(
         self,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicValueRequirementImpl.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the ClassicValueRequirementImpl object"""
+"""Contains the ClassicValueRequirementImpl object."""
 
 import textwrap
 
@@ -16,6 +16,8 @@ from ...Impl.ValueRequirementImpl import DoesNotApplyResult, ValueRequirementImp
 
 # ----------------------------------------------------------------------
 class ClassicValueRequirementImpl(ValueRequirementImpl):
+    """Implementation of a requirement that checks a classic value in GitHub settings."""
+
     # ----------------------------------------------------------------------
     def __init__(
         self,

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireApprovalMostRecentPush object"""
+"""Contains the RequireApprovalMostRecentPush object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireApprovalMostRecentPush(ClassicEnableRequirementImpl):
+    """Require approval of the most recent reviewable push."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireApprovals object"""
+"""Contains the RequireApprovals object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.ClassicValueRequirementImpl import ClassicValueRequirementImpl, DoesN
 
 # ----------------------------------------------------------------------
 class RequireApprovals(ClassicValueRequirementImpl):
+    """Require approvals for pull requests."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireCodeOwnerReview object"""
+"""Contains the RequireCodeOwnerReview object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireCodeOwnerReview(ClassicEnableRequirementImpl):
+    """Requirement of review from code owners."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireConversationResolution object"""
+"""Contains the RequireConversationResolution object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireConversationResolution(ClassicEnableRequirementImpl):
+    """Require conversation resolution before merging."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireLinearHistory object"""
+"""Contains the RequireLinearHistory object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireLinearHistory(ClassicEnableRequirementImpl):
+    """Require a linear history."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequirePullRequests object"""
+"""Contains the RequirePullRequests object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequirePullRequests(ClassicEnableRequirementImpl):
+    """Require a pull request before merging."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireSignedCommits object"""
+"""Contains the RequireSignedCommits object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireSignedCommits(ClassicEnableRequirementImpl):
+    """Require signed commits."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireStatusChecksToPass object"""
+"""Contains the RequireStatusChecksToPass object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireStatusChecksToPass(ClassicEnableRequirementImpl):
+    """Require status checks to pass before merging pull requests."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RequireUpToDateBranches object"""
+"""Contains the RequireUpToDateBranches object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RequireUpToDateBranches(ClassicEnableRequirementImpl):
+    """Require branches to be up to date before merging."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQuery.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the DefaultBranchQuery object"""
+"""Contains the DefaultBranchQuery object."""
 
 from typing import Any, Optional
 
@@ -35,6 +35,7 @@ class DefaultBranchQuery(Query):
         self,
         module_data: dict[str, Any],
     ) -> Optional[dict[str, Any]]:
+        """Get the data from an API session."""
         # Get the default branch name
         response = module_data["session"].get("")
 

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the Protected object"""
+"""Contains the Protected object."""
 
 import textwrap
 
@@ -21,6 +21,8 @@ from ..Impl.Common import CreateIncompleteDataResult
 
 # ----------------------------------------------------------------------
 class Protected(Requirement):
+    """Requirement to ensure that the mainline branch is protected."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         # Note that protected is set for the branch when creating a branch ruleset or a classic
@@ -54,6 +56,7 @@ class Protected(Requirement):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             "false": (
                 bool,

--- a/src/RepoAuditor/Plugins/GitHub/Impl/Common.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/Common.py
@@ -11,6 +11,7 @@ from RepoAuditor.Requirement import EvaluateResult, Requirement
 
 # ----------------------------------------------------------------------
 def CreateIncompleteDataResult() -> Requirement.EvaluateImplResult:
+    """Create an incomplete data result."""
     return Requirement.EvaluateImplResult(
         EvaluateResult.Warning,
         "Incomplete data was encountered; please provide the GitHub PAT or update the PAT's permissions if one was provided.",

--- a/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the EnableRequirementImpl object"""
+"""Contains the EnableRequirementImpl object."""
 
 from typing import Any, Optional
 from collections.abc import Callable
@@ -63,6 +63,7 @@ class EnableRequirementImpl(Requirement):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             self.dynamic_arg_name: (
                 bool,

--- a/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the ValueRequirementImpl object"""
+"""Contains the ValueRequirementImpl object."""
 
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -71,6 +71,7 @@ class ValueRequirementImpl(Requirement):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             "value": (
                 str,

--- a/src/RepoAuditor/Plugins/GitHub/Module.py
+++ b/src/RepoAuditor/Plugins/GitHub/Module.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the GitHubModule object"""
+"""Contains the GitHubModule object."""
 
 from pathlib import Path
 from typing import Any, Optional
@@ -25,6 +25,8 @@ from .StandardQuery import StandardQuery
 
 # ----------------------------------------------------------------------
 class GitHubModule(Module):
+    """Module for validating GitHub repository configuration settings."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(
@@ -42,6 +44,7 @@ class GitHubModule(Module):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             "url": (
                 str,
@@ -69,6 +72,8 @@ class GitHubModule(Module):
     # ----------------------------------------------------------------------
     @override
     def GenerateInitialData(self, dynamic_args: dict[str, Any]) -> Optional[dict[str, Any]]:
+        """Generate the initial data to be used in the `dynamic_args`, such as session info, etc."""
+        # Create a GitHub API session
         dynamic_args["session"] = _GitHubSession(dynamic_args["url"], dynamic_args.get("pat"))
 
         return dynamic_args
@@ -80,7 +85,7 @@ class GitHubModule(Module):
 # |
 # ----------------------------------------------------------------------
 class _GitHubSession(requests.Session):
-    """Session used to communicate with GitHub APIs"""
+    """Session used to communicate with GitHub APIs."""
 
     # ----------------------------------------------------------------------
     def __init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the StandardQuery object"""
+"""Contains the StandardQuery object."""
 
 from typing import Any, Optional
 
@@ -234,6 +234,7 @@ class StandardQuery(Query):
         self,
         module_data: dict[str, Any],
     ) -> Optional[dict[str, Any]]:
+        """Get the data from an API session."""
         response = module_data["session"].get("")
 
         response.raise_for_status()

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the AutoMerge object"""
+"""Contains the AutoMerge object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class AutoMerge(StandardEnableRequirementImpl):
+    """Requirement to enable auto-merge for pull requests."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the DefaultBranch object"""
+"""Contains the DefaultBranch object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
 
 # ----------------------------------------------------------------------
 class DefaultBranch(StandardValueRequirementImpl):
+    """Requirement of a default branch in the repository."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the DeleteHeadBranches object"""
+"""Contains the DeleteHeadBranches object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class DeleteHeadBranches(StandardEnableRequirementImpl):
+    """Requirement to delete head branches."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the DependabotSecurityUpdates object"""
+"""Contains the DependabotSecurityUpdates object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class DependabotSecurityUpdates(StandardEnableRequirementImpl):
+    """Requirement of Dependabot security updates."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the Description object"""
+"""Contains the Description object."""
 
 import textwrap
 
@@ -22,6 +22,8 @@ from ..Impl.Common import CreateIncompleteDataResult
 
 # ----------------------------------------------------------------------
 class Description(Requirement):
+    """Requirement to validate a repository's description."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(
@@ -54,6 +56,7 @@ class Description(Requirement):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             "allow-empty": (
                 bool,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the StandardEnableRequirementImpl object"""
+"""Contains the StandardEnableRequirementImpl object."""
 
 import textwrap
 
@@ -16,6 +16,8 @@ from ...Impl.EnableRequirementImpl import EnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class StandardEnableRequirementImpl(EnableRequirementImpl):
+    """Implementation of requirement for standard enables of GitHub settings."""
+
     # ----------------------------------------------------------------------
     def __init__(
         self,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardValueRequirementImpl.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the StandardValueRequirementImpl object"""
+"""Contains the StandardValueRequirementImpl object."""
 
 import textwrap
 
@@ -18,6 +18,8 @@ from ...Impl.ValueRequirementImpl import DoesNotApplyResult, ValueRequirementImp
 class StandardValueRequirementImpl(
     ValueRequirementImpl,
 ):
+    """Requirement that checks a specific value against a standard value in GitHub settings."""
+
     # ----------------------------------------------------------------------
     def __init__(
         self,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the License object"""
+"""Contains the License object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
 
 # ----------------------------------------------------------------------
 class License(StandardValueRequirementImpl):
+    """Default License as MIT Requirement."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the MergeCommit object"""
+"""Contains the MergeCommit object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class MergeCommit(StandardEnableRequirementImpl):
+    """Allow merge commits requirement."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the MergeCommitMessage object"""
+"""Contains the MergeCommitMessage object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValue
 
 # ----------------------------------------------------------------------
 class MergeCommitMessage(StandardValueRequirementImpl):
+    """Allow merge commit message requirement."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the Private object"""
+"""Contains the Private object."""
 
 import textwrap
 from typing import Any
@@ -21,6 +21,8 @@ from ..Impl.Common import CreateIncompleteDataResult
 
 # ----------------------------------------------------------------------
 class Private(Requirement):
+    """Validates that the repository is set to the expected visibility."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(
@@ -53,6 +55,7 @@ class Private(Requirement):
     # ----------------------------------------------------------------------
     @override
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
+        """Get the definitions for the arguments to this requirement."""
         return {
             "true": (
                 bool,

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the RebaseMergeCommit object"""
+"""Contains the RebaseMergeCommit object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class RebaseMergeCommit(StandardEnableRequirementImpl):
+    """Allow rebase merging requirement."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SecretScanning object"""
+"""Contains the SecretScanning object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SecretScanning(StandardEnableRequirementImpl):
+    """Secret scanning enable requirement."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SecretScanningPushProtection object"""
+"""Contains the SecretScanningPushProtection object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SecretScanningPushProtection(StandardEnableRequirementImpl):
+    """Push protection for secret scanning."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SquashCommitMerge object"""
+"""Contains the SquashCommitMerge object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SquashCommitMerge(StandardEnableRequirementImpl):
+    """Allow squash merging."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SquashMergeCommitMessage object"""
+"""Contains the SquashMergeCommitMessage object."""
 
 import textwrap
 
@@ -15,6 +15,8 @@ from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValue
 
 # ----------------------------------------------------------------------
 class SquashMergeCommitMessage(StandardValueRequirementImpl):
+    """Set default commit message for squash merges."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SuggestUpdatingPullRequestBranches object"""
+"""Contains the SuggestUpdatingPullRequestBranches object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SuggestUpdatingPullRequestBranches(StandardEnableRequirementImpl):
+    """Always suggest updating pull request branches."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SupportDiscussions object"""
+"""Contains the SupportDiscussions object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SupportDiscussions(StandardEnableRequirementImpl):
+    """Support for Discussions."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SupportIssues object"""
+"""Contains the SupportIssues object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SupportIssues(StandardEnableRequirementImpl):
+    """Support for Issues."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SupportProjects object"""
+"""Contains the SupportProjects object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SupportProjects(StandardEnableRequirementImpl):
+    """Support for Projects."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the SupportWikis object"""
+"""Contains the SupportWikis object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class SupportWikis(StandardEnableRequirementImpl):
+    """Support for Wikis."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the TemplateRepository object"""
+"""Contains the TemplateRepository object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class TemplateRepository(StandardEnableRequirementImpl):
+    """Template repository."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the WebCommitSignoff object"""
+"""Contains the WebCommitSignoff object."""
 
 import textwrap
 
@@ -13,6 +13,8 @@ from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
 
 # ----------------------------------------------------------------------
 class WebCommitSignoff(StandardEnableRequirementImpl):
+    """Require contributors to sign off on web-based commits."""
+
     # ----------------------------------------------------------------------
     def __init__(self) -> None:
         super().__init__(

--- a/src/RepoAuditor/Plugins/GitHubPlugin.py
+++ b/src/RepoAuditor/Plugins/GitHubPlugin.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains Plugin functionality"""
+"""Contains Plugin functionality."""
 
 import pluggy
 
@@ -17,4 +17,5 @@ from .GitHub.Module import GitHubModule
 # ----------------------------------------------------------------------
 @pluggy.HookimplMarker(APP_NAME)
 def GetModule() -> Module:
+    """Return GitHub Module."""
     return GitHubModule()

--- a/src/RepoAuditor/Query.py
+++ b/src/RepoAuditor/Query.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Contains the Query object and types used in its definition"""
+"""Contains the Query object and types used in its definition."""
 
 import threading
 
@@ -18,7 +18,9 @@ from .Requirement import EvaluateResult, ExecutionStyle, Requirement
 
 # ----------------------------------------------------------------------
 class OnStatusFunc(Protocol):
-    def __call__(
+    """Functional to report status information."""
+
+    def __call__(  # noqa: D102
         self,
         num_completed: int,
         num_success: int,
@@ -64,7 +66,7 @@ class Query(ABC):
         self,
         module_data: dict[str, Any],
     ) -> Optional[dict[str, Any]]:
-        """Returns the data object augmented with information required by the Requirements associated with this Query."""
+        """Return the data object augmented with information required by the Requirements associated with this Query."""
 
     # ----------------------------------------------------------------------
     def Evaluate(
@@ -75,6 +77,7 @@ class Query(ABC):
         *,
         max_num_threads: Optional[int] = None,
     ) -> list["Query.EvaluateInfo"]:
+        """Evaluate the Query given the query data and the data from the requirements."""
         status_info = StatusInfo()
         status_info_lock = threading.Lock()
 

--- a/src/RepoAuditor/Requirement.py
+++ b/src/RepoAuditor/Requirement.py
@@ -51,6 +51,8 @@ class Requirement(ABC):
     # ----------------------------------------------------------------------
     @dataclass(frozen=True)
     class EvaluateImplResult:
+        """Result of evaluating a Requirement."""
+
         result: EvaluateResult
         context: Optional[str]
         provide_resolution: bool = field(kw_only=True, default=False)
@@ -69,8 +71,12 @@ class Requirement(ABC):
         resolution_template: str,
         rationale_template: str,
         *,
-        requires_explicit_include: bool = False,  # If True, the requirement must be explicitly included on the command line
+        requires_explicit_include: bool = False,
     ) -> None:
+        """Initialize the requirement with the given name, description, and style.
+
+        If `requires_explicit_include` is True, the requirement must be explicitly included on the command line.
+        """
         self.name = name
         self.description = description
         self.style = style
@@ -83,7 +89,7 @@ class Requirement(ABC):
     # ----------------------------------------------------------------------
     @extension
     def GetDynamicArgDefinitions(self) -> dict[str, TypeDefinitionItemType]:
-        """Returns information about dynamic arguments that the requirement can consume (often from the command line)."""
+        """Return information about dynamic arguments that the requirement can consume (often from the command line)."""
 
         # No dynamic arguments by default
         return {}
@@ -94,6 +100,7 @@ class Requirement(ABC):
         query_data: dict[str, Any],
         requirement_args: dict[str, Any],
     ) -> "Requirement.EvaluateInfo":
+        """Evaluate the requirements given the query data and specific arguments."""
         result_info = self._EvaluateImpl(query_data, requirement_args)
 
         if result_info.result == EvaluateResult.Error:
@@ -118,4 +125,4 @@ class Requirement(ABC):
         query_data: dict[str, Any],
         requirement_args: dict[str, Any],
     ) -> "Requirement.EvaluateImplResult":
-        """Perform the actual evaluation"""
+        """Perform the actual evaluation."""


### PR DESCRIPTION
## :pencil: Description
Address linter errors from D ruleset.

- Update docstrings to be imperative and have punctuations.
- Add docstrings. I have used CoPilot to do the heavy lifting for these, updating them based on high level understanding of the code.
- I disabled specific warnings for missing docstrings in `__init__.py`, the public package, and public nested classes. Please let me know if this is not intended behavior.

## :gear: Work Item
#57 

## :movie_camera: Demo
Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.
