### PR TITLE
Sort Imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ repos:
     require_serial: true
     always_run: true
 
+  - id: uv run ruff check --select I --fix
+    name: ruff sort imports
+    entry: uv run ruff check --select I --fix
+    language: system
+    pass_filenames: false
+    always_run: true
+
   - id: uv run ruff format --check
     name: uv run ruff format --check
     entry: uv run ruff format --check

--- a/src/RepoAuditor/CommandLineProcessor.py
+++ b/src/RepoAuditor/CommandLineProcessor.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol
 
 from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]
 
-from .ExecuteModules import Execute, Module, ModuleInfo
+from RepoAuditor.ExecuteModules import Execute, Module, ModuleInfo
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Display.py
+++ b/src/RepoAuditor/Display.py
@@ -9,13 +9,13 @@
 import textwrap
 from typing import Optional
 
-from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]
 from dbrownell_Common import TextwrapEx  # type: ignore[import-untyped]
+from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]
 from rich import print as rich_print
 from rich.console import Group
 from rich.panel import Panel
 
-from .Module import EvaluateResult, Module
+from RepoAuditor.Module import EvaluateResult, Module
 
 
 def GetInternalPanelContent(

--- a/src/RepoAuditor/EntryPoint.py
+++ b/src/RepoAuditor/EntryPoint.py
@@ -9,23 +9,22 @@
 import sys
 import textwrap
 import traceback
-
 from typing import Annotated, Optional
 
 import pluggy
 import typer
-
 from click.exceptions import UsageError
-from dbrownell_Common.Streams.DoneManager import DoneManager, Flags as DoneManagerFlags  # type: ignore [import-untyped]
-from dbrownell_Common import TextwrapEx  # type: ignore [import-untyped]
-from dbrownell_Common import TyperEx  # type: ignore [import-untyped]
+from dbrownell_Common import (
+    TextwrapEx,  # type: ignore [import-untyped]
+    TyperEx,  # type: ignore [import-untyped]
+)
+from dbrownell_Common.Streams.DoneManager import DoneManager
+from dbrownell_Common.Streams.DoneManager import Flags as DoneManagerFlags  # type: ignore [import-untyped]
 from typer.core import TyperGroup  # type: ignore [import-untyped]
 
-from RepoAuditor import APP_NAME, __version__
+from RepoAuditor import APP_NAME, Plugin, __version__
 from RepoAuditor.CommandLineProcessor import CommandLineProcessor, Module
 from RepoAuditor.Display import DisplayResults
-from RepoAuditor import Plugin
-
 
 # ----------------------------------------------------------------------
 ARGUMENT_SEPARATOR = "-"

--- a/src/RepoAuditor/ExecuteModules.py
+++ b/src/RepoAuditor/ExecuteModules.py
@@ -8,10 +8,9 @@
 
 import itertools
 import sys
-
-from dataclasses import dataclass
-from typing import Any, cast, Optional
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Optional, cast
 
 from dbrownell_Common import ExecuteTasks  # type: ignore[import-untyped]
 from dbrownell_Common.InflectEx import inflect  # type: ignore[import-untyped]
@@ -19,7 +18,7 @@ from dbrownell_Common.Streams.Capabilities import Capabilities  # type: ignore[i
 from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]
 from rich.progress import Progress, TimeElapsedColumn
 
-from .Module import EvaluateResult, ExecutionStyle, Module, OnStatusFunc
+from RepoAuditor.Module import EvaluateResult, ExecutionStyle, Module, OnStatusFunc
 
 
 # ----------------------------------------------------------------------
@@ -211,7 +210,7 @@ def Execute(
                 # rather than referencing `sys.stdout` directly, but it is really hard to work with mocked
                 # stream as mocks will create mocks for everything called on the mock. Use sys.stdout
                 # directly to avoid that particular problem.
-                from unittest.mock import Mock, MagicMock
+                from unittest.mock import MagicMock, Mock
 
                 assert stdout_context.stream is sys.stdout or isinstance(
                     stdout_context.stream, (Mock, MagicMock)

--- a/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
+++ b/src/RepoAuditor/Impl/ParallelSequentialProcessor.py
@@ -6,9 +6,9 @@
 # -------------------------------------------------------------------------------
 """Contains functionality to process items in parallel and/or sequentially."""
 
-from enum import auto, Enum
-from typing import cast, TypeVar, Optional
 from collections.abc import Callable
+from enum import Enum, auto
+from typing import Optional, TypeVar, cast
 
 from dbrownell_Common import ExecuteTasks  # type: ignore[import-untyped]
 from dbrownell_Common.Streams.DoneManager import DoneManager  # type: ignore[import-untyped]

--- a/src/RepoAuditor/Module.py
+++ b/src/RepoAuditor/Module.py
@@ -7,15 +7,14 @@
 """Contains the Module object and types used in its definition."""
 
 import threading
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 
-from .Impl.ParallelSequentialProcessor import ParallelSequentialProcessor
-from .Query import EvaluateResult, ExecutionStyle, OnStatusFunc, Query, StatusInfo
+from RepoAuditor.Impl.ParallelSequentialProcessor import ParallelSequentialProcessor
+from RepoAuditor.Query import EvaluateResult, ExecutionStyle, OnStatusFunc, Query, StatusInfo
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugin.py
+++ b/src/RepoAuditor/Plugin.py
@@ -9,8 +9,7 @@
 import pluggy
 
 from RepoAuditor import APP_NAME
-
-from .Module import Module
+from RepoAuditor.Module import Module
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionQuery.py
@@ -64,28 +64,43 @@ from typing import Any, Optional
 import requests
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
-from RepoAuditor.Query import ExecutionStyle, Query
-
-from .ClassicBranchProtectionRequirements.AllowDeletions import AllowDeletions
-from .ClassicBranchProtectionRequirements.AllowForcePushes import AllowForcePushes
-from .ClassicBranchProtectionRequirements.DismissStalePullRequestApprovals import (
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.AllowDeletions import AllowDeletions
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.AllowForcePushes import AllowForcePushes
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.DismissStalePullRequestApprovals import (
     DismissStalePullRequestApprovals,
 )
-from .ClassicBranchProtectionRequirements.DoNotAllowBypassSettings import DoNotAllowBypassSettings
-from .ClassicBranchProtectionRequirements.EnsureStatusChecks import EnsureStatusChecks
-from .ClassicBranchProtectionRequirements.RequireApprovalMostRecentPush import (
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.DoNotAllowBypassSettings import (
+    DoNotAllowBypassSettings,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.EnsureStatusChecks import (
+    EnsureStatusChecks,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireApprovalMostRecentPush import (
     RequireApprovalMostRecentPush,
 )
-from .ClassicBranchProtectionRequirements.RequireApprovals import RequireApprovals
-from .ClassicBranchProtectionRequirements.RequireCodeOwnerReview import RequireCodeOwnerReview
-from .ClassicBranchProtectionRequirements.RequireConversationResolution import (
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireApprovals import RequireApprovals
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireCodeOwnerReview import (
+    RequireCodeOwnerReview,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireConversationResolution import (
     RequireConversationResolution,
 )
-from .ClassicBranchProtectionRequirements.RequireLinearHistory import RequireLinearHistory
-from .ClassicBranchProtectionRequirements.RequirePullRequests import RequirePullRequests
-from .ClassicBranchProtectionRequirements.RequireSignedCommits import RequireSignedCommits
-from .ClassicBranchProtectionRequirements.RequireStatusChecksToPass import RequireStatusChecksToPass
-from .ClassicBranchProtectionRequirements.RequireUpToDateBranches import RequireUpToDateBranches
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireLinearHistory import (
+    RequireLinearHistory,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequirePullRequests import (
+    RequirePullRequests,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireSignedCommits import (
+    RequireSignedCommits,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireStatusChecksToPass import (
+    RequireStatusChecksToPass,
+)
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireUpToDateBranches import (
+    RequireUpToDateBranches,
+)
+from RepoAuditor.Query import ExecutionStyle, Query
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowDeletions.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/AllowForcePushes.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals.py
@@ -7,10 +7,11 @@
 """Contains the DismissStalePullRequestApprovals object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/DoNotAllowBypassSettings.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/EnsureStatusChecks.py
@@ -7,13 +7,12 @@
 """Contains the EnsureStatusChecks object."""
 
 import textwrap
-
 from typing import Any
 
 import typer
-
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
+
 from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
 
 

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicEnableRequirementImpl.py
@@ -7,9 +7,8 @@
 """Contains the ClassicEnableRequirementImpl object."""
 
 import textwrap
-
-from typing import Any, Optional
 from collections.abc import Callable
+from typing import Any, Optional
 
 from RepoAuditor.Plugins.GitHub.Impl.EnableRequirementImpl import EnableRequirementImpl
 

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/Impl/ClassicValueRequirementImpl.py
@@ -7,9 +7,8 @@
 """Contains the ClassicValueRequirementImpl object."""
 
 import textwrap
-
-from typing import Any, Optional
 from collections.abc import Callable
+from typing import Any, Optional
 
 from RepoAuditor.Plugins.GitHub.Impl.ValueRequirementImpl import DoesNotApplyResult, ValueRequirementImpl
 

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush.py
@@ -7,10 +7,11 @@
 """Contains the RequireApprovalMostRecentPush object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireApprovals.py
@@ -7,10 +7,12 @@
 """Contains the RequireApprovals object."""
 
 import textwrap
-
 from typing import Any
 
-from .Impl.ClassicValueRequirementImpl import ClassicValueRequirementImpl, DoesNotApplyResult
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicValueRequirementImpl import (
+    ClassicValueRequirementImpl,
+    DoesNotApplyResult,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireCodeOwnerReview.py
@@ -7,10 +7,11 @@
 """Contains the RequireCodeOwnerReview object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireConversationResolution.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireLinearHistory.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequirePullRequests.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireSignedCommits.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireStatusChecksToPass.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/ClassicBranchProtectionRequirements/RequireUpToDateBranches.py
@@ -7,10 +7,11 @@
 """Contains the RequireUpToDateBranches object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.ClassicEnableRequirementImpl import ClassicEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.Impl.ClassicEnableRequirementImpl import (
+    ClassicEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQuery.py
@@ -10,9 +10,8 @@ from typing import Any, Optional
 
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
+from RepoAuditor.Plugins.GitHub.DefaultBranchQueryRequirements.Protected import Protected
 from RepoAuditor.Query import ExecutionStyle, Query
-
-from .DefaultBranchQueryRequirements.Protected import Protected
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
+++ b/src/RepoAuditor/Plugins/GitHub/DefaultBranchQueryRequirements/Protected.py
@@ -7,13 +7,12 @@
 """Contains the Protected object."""
 
 import textwrap
-
 from typing import Any
 
 import typer
-
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
+
 from RepoAuditor.Plugins.GitHub.Impl.Common import CreateIncompleteDataResult
 from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
 

--- a/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/EnableRequirementImpl.py
@@ -6,17 +6,15 @@
 # -------------------------------------------------------------------------------
 """Contains the EnableRequirementImpl object."""
 
-from typing import Any, Optional
 from collections.abc import Callable
+from typing import Any, Optional
 
 import typer
-
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
+from RepoAuditor.Plugins.GitHub.Impl.Common import CreateIncompleteDataResult
 from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
-
-from .Common import CreateIncompleteDataResult
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/Impl/ValueRequirementImpl.py
@@ -6,18 +6,16 @@
 # -------------------------------------------------------------------------------
 """Contains the ValueRequirementImpl object."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Optional
-from collections.abc import Callable
 
 import typer
-
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
+from RepoAuditor.Plugins.GitHub.Impl.Common import CreateIncompleteDataResult
 from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
-
-from .Common import CreateIncompleteDataResult
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/Module.py
+++ b/src/RepoAuditor/Plugins/GitHub/Module.py
@@ -7,11 +7,10 @@
 """Contains the GitHubModule object."""
 
 from RepoAuditor.Module import ExecutionStyle
+from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionQuery import ClassicBranchProtectionQuery
+from RepoAuditor.Plugins.GitHub.DefaultBranchQuery import DefaultBranchQuery
+from RepoAuditor.Plugins.GitHub.StandardQuery import StandardQuery
 from RepoAuditor.Plugins.GitHubBase.Module import GitHubBaseModule
-
-from .ClassicBranchProtectionQuery import ClassicBranchProtectionQuery
-from .DefaultBranchQuery import DefaultBranchQuery
-from .StandardQuery import StandardQuery
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQuery.py
@@ -170,31 +170,36 @@ from typing import Any, Optional
 
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
-from RepoAuditor.Query import ExecutionStyle, Query
-
-from .StandardQueryRequirements.AutoMerge import AutoMerge
-from .StandardQueryRequirements.DefaultBranch import DefaultBranch
-from .StandardQueryRequirements.DeleteHeadBranches import DeleteHeadBranches
-from .StandardQueryRequirements.Description import Description
-from .StandardQueryRequirements.DependabotSecurityUpdates import DependabotSecurityUpdates
-from .StandardQueryRequirements.License import License
-from .StandardQueryRequirements.MergeCommit import MergeCommit
-from .StandardQueryRequirements.MergeCommitMessage import MergeCommitMessage
-from .StandardQueryRequirements.Private import Private
-from .StandardQueryRequirements.RebaseMergeCommit import RebaseMergeCommit
-from .StandardQueryRequirements.SecretScanning import SecretScanning
-from .StandardQueryRequirements.SecretScanningPushProtection import SecretScanningPushProtection
-from .StandardQueryRequirements.SquashCommitMerge import SquashCommitMerge
-from .StandardQueryRequirements.SquashMergeCommitMessage import SquashMergeCommitMessage
-from .StandardQueryRequirements.SuggestUpdatingPullRequestBranches import (
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.AutoMerge import AutoMerge
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.DefaultBranch import DefaultBranch
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.DeleteHeadBranches import DeleteHeadBranches
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.DependabotSecurityUpdates import (
+    DependabotSecurityUpdates,
+)
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Description import Description
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.License import License
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.MergeCommit import MergeCommit
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.MergeCommitMessage import MergeCommitMessage
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Private import Private
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.RebaseMergeCommit import RebaseMergeCommit
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SecretScanning import SecretScanning
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SecretScanningPushProtection import (
+    SecretScanningPushProtection,
+)
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SquashCommitMerge import SquashCommitMerge
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SquashMergeCommitMessage import (
+    SquashMergeCommitMessage,
+)
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SuggestUpdatingPullRequestBranches import (
     SuggestUpdatingPullRequestBranches,
 )
-from .StandardQueryRequirements.SupportDiscussions import SupportDiscussions
-from .StandardQueryRequirements.SupportIssues import SupportIssues
-from .StandardQueryRequirements.SupportProjects import SupportProjects
-from .StandardQueryRequirements.SupportWikis import SupportWikis
-from .StandardQueryRequirements.TemplateRepository import TemplateRepository
-from .StandardQueryRequirements.WebCommitSignoff import WebCommitSignoff
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SupportDiscussions import SupportDiscussions
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SupportIssues import SupportIssues
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SupportProjects import SupportProjects
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.SupportWikis import SupportWikis
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.TemplateRepository import TemplateRepository
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.WebCommitSignoff import WebCommitSignoff
+from RepoAuditor.Query import ExecutionStyle, Query
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/AutoMerge.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DefaultBranch.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardValueRequirementImpl import (
+    StandardValueRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DeleteHeadBranches.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/DependabotSecurityUpdates.py
@@ -7,10 +7,11 @@
 """Contains the DependabotSecurityUpdates object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Description.py
@@ -7,13 +7,11 @@
 """Contains the Description object."""
 
 import textwrap
-
 from typing import Any
 
 import typer
-
-from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
+from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
 from RepoAuditor.Plugins.GitHub.Impl.Common import CreateIncompleteDataResult
 from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardEnableRequirementImpl.py
@@ -7,9 +7,8 @@
 """Contains the StandardEnableRequirementImpl object."""
 
 import textwrap
-
-from typing import Any, Optional
 from collections.abc import Callable
+from typing import Any, Optional
 
 from RepoAuditor.Plugins.GitHub.Impl.EnableRequirementImpl import EnableRequirementImpl
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardValueRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Impl/StandardValueRequirementImpl.py
@@ -7,9 +7,8 @@
 """Contains the StandardValueRequirementImpl object."""
 
 import textwrap
-
-from typing import Any, Optional
 from collections.abc import Callable
+from typing import Any, Optional
 
 from RepoAuditor.Plugins.GitHub.Impl.ValueRequirementImpl import DoesNotApplyResult, ValueRequirementImpl
 

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/License.py
@@ -7,10 +7,11 @@
 """Contains the License object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.StandardValueRequirementImpl import StandardValueRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardValueRequirementImpl import (
+    StandardValueRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommit.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/MergeCommitMessage.py
@@ -7,10 +7,12 @@
 """Contains the MergeCommitMessage object."""
 
 import textwrap
-
 from typing import Any
 
-from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValueRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardValueRequirementImpl import (
+    DoesNotApplyResult,
+    StandardValueRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/Private.py
@@ -10,9 +10,8 @@ import textwrap
 from typing import Any
 
 import typer
-
-from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
+from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
 from RepoAuditor.Plugins.GitHub.Impl.Common import CreateIncompleteDataResult
 from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/RebaseMergeCommit.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanning.py
@@ -7,10 +7,11 @@
 """Contains the SecretScanning object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SecretScanningPushProtection.py
@@ -7,10 +7,11 @@
 """Contains the SecretScanningPushProtection object."""
 
 import textwrap
-
 from typing import Any, Optional
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashMergeCommitMessage.py
@@ -7,10 +7,12 @@
 """Contains the SquashMergeCommitMessage object."""
 
 import textwrap
-
 from typing import Any
 
-from .Impl.StandardValueRequirementImpl import DoesNotApplyResult, StandardValueRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardValueRequirementImpl import (
+    DoesNotApplyResult,
+    StandardValueRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SuggestUpdatingPullRequestBranches.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportDiscussions.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportIssues.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportProjects.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SupportWikis.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/TemplateRepository.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/WebCommitSignoff.py
@@ -8,7 +8,9 @@
 
 import textwrap
 
-from .Impl.StandardEnableRequirementImpl import StandardEnableRequirementImpl
+from RepoAuditor.Plugins.GitHub.StandardQueryRequirements.Impl.StandardEnableRequirementImpl import (
+    StandardEnableRequirementImpl,
+)
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHubBase/Module.py
+++ b/src/RepoAuditor/Plugins/GitHubBase/Module.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 
 import requests
 import typer
-
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 

--- a/src/RepoAuditor/Plugins/GitHubCustomization/CustomizationQuery.py
+++ b/src/RepoAuditor/Plugins/GitHubCustomization/CustomizationQuery.py
@@ -6,18 +6,18 @@
 # -------------------------------------------------------------------------------
 """Contains the CustomizationQuery object."""
 
-from typing import Any, Optional
 from tempfile import TemporaryDirectory
-from git import Repo
+from typing import Any, Optional
 
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
+from git import Repo
 
-from RepoAuditor.Query import ExecutionStyle, Query
 from RepoAuditor.Plugins.GitHubCustomization.Requirements.CodeOwners import CodeOwners
 from RepoAuditor.Plugins.GitHubCustomization.Requirements.Contributing import Contributing
 from RepoAuditor.Plugins.GitHubCustomization.Requirements.IssueTemplates import IssueTemplates
 from RepoAuditor.Plugins.GitHubCustomization.Requirements.PullRequestTemplates import PullRequestTemplate
 from RepoAuditor.Plugins.GitHubCustomization.Requirements.SecurityPolicy import SecurityPolicy
+from RepoAuditor.Query import ExecutionStyle, Query
 
 
 class CustomizationQuery(Query):

--- a/src/RepoAuditor/Plugins/GitHubCustomization/Impl/ExistsRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHubCustomization/Impl/ExistsRequirementImpl.py
@@ -6,12 +6,11 @@
 # -------------------------------------------------------------------------------
 """Contains the ExistsRequirementImpl object."""
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
-from collections.abc import Sequence
 
 import typer
-
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 

--- a/src/RepoAuditor/Plugins/GitHubPlugin.py
+++ b/src/RepoAuditor/Plugins/GitHubPlugin.py
@@ -10,8 +10,7 @@ import pluggy
 
 from RepoAuditor import APP_NAME
 from RepoAuditor.Module import Module
-
-from .GitHub.Module import GitHubModule
+from RepoAuditor.Plugins.GitHub.Module import GitHubModule
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHubRulesets/Impl/EnableRulesetRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHubRulesets/Impl/EnableRulesetRequirementImpl.py
@@ -6,13 +6,13 @@
 # -------------------------------------------------------------------------------
 """Contains the EnableRequirementImpl object."""
 
-from typing import Any, Optional
 from collections.abc import Callable
+from typing import Any, Optional
 
 from dbrownell_Common.Types import override  # type: ignore[import-untyped]
 
-from RepoAuditor.Requirement import EvaluateResult, Requirement
 from RepoAuditor.Plugins.GitHub.Impl.EnableRequirementImpl import EnableRequirementImpl
+from RepoAuditor.Requirement import EvaluateResult, Requirement
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHubRulesets/RulesetQuery.py
+++ b/src/RepoAuditor/Plugins/GitHubRulesets/RulesetQuery.py
@@ -9,11 +9,12 @@
 from typing import Any, Optional
 
 from dbrownell_Common.Types import override
+
 from RepoAuditor.Impl.ParallelSequentialProcessor import ExecutionStyle
-from RepoAuditor.Query import Query
 from RepoAuditor.Plugins.GitHubRulesets.Requirements.RequirePullRequests import RequirePullRequests
 from RepoAuditor.Plugins.GitHubRulesets.Requirements.RequireSignedCommits import RequireSignedCommits
 from RepoAuditor.Plugins.GitHubRulesets.Requirements.RequireStatusChecks import RequireStatusChecks
+from RepoAuditor.Query import Query
 
 
 class RulesetQuery(Query):

--- a/src/RepoAuditor/Plugins/GitHubRulesetsPlugin.py
+++ b/src/RepoAuditor/Plugins/GitHubRulesetsPlugin.py
@@ -10,7 +10,6 @@ import pluggy
 
 from RepoAuditor import APP_NAME
 from RepoAuditor.Module import Module
-
 from RepoAuditor.Plugins.GitHubRulesets.Module import GitHubRulesetsModule
 
 

--- a/src/RepoAuditor/Query.py
+++ b/src/RepoAuditor/Query.py
@@ -7,13 +7,12 @@
 """Contains the Query object and types used in its definition."""
 
 import threading
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Protocol, Optional
+from typing import Any, Optional, Protocol
 
-from .Impl.ParallelSequentialProcessor import ParallelSequentialProcessor
-from .Requirement import EvaluateResult, ExecutionStyle, Requirement
+from RepoAuditor.Impl.ParallelSequentialProcessor import ParallelSequentialProcessor
+from RepoAuditor.Requirement import EvaluateResult, ExecutionStyle, Requirement
 
 
 # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Requirement.py
+++ b/src/RepoAuditor/Requirement.py
@@ -8,13 +8,13 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from enum import auto, Enum
+from enum import Enum, auto
 from typing import Any, Optional
 
 from dbrownell_Common.TyperEx import TypeDefinitionItemType  # type: ignore[import-untyped]
 from dbrownell_Common.Types import extension  # type: ignore[import-untyped]
 
-from .Impl.ParallelSequentialProcessor import ExecutionStyle
+from RepoAuditor.Impl.ParallelSequentialProcessor import ExecutionStyle
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## :pencil: Description
I ran `uv run ruff check --select I --fix` to sort all the imports in the source files.
Not only has this sorted and grouped the imports nicely, it plays well with @davidbrownell's original scheme and provides us with a standardized way to format our code.

Additionally, I also converted all relative imports to absolute imports.

## :gear: Work Item
Fixes #105 

## :movie_camera: Demo
Everything is nicely sorted! My OCD is happy.