### PR TITLE
Check both upper and lower case filenames in GitHubCustomization

### DIFF
--- a/src/RepoAuditor/Plugins/GitHubCustomization/Impl/ExistsRequirementImpl.py
+++ b/src/RepoAuditor/Plugins/GitHubCustomization/Impl/ExistsRequirementImpl.py
@@ -44,6 +44,7 @@ class ExistsRequirementImpl(Requirement):
 
         self.dynamic_arg_name = dynamic_arg_name
         self.github_file = github_file
+
         self.possible_locations = possible_locations
 
     # ----------------------------------------------------------------------

--- a/src/RepoAuditor/Plugins/GitHubCustomization/Requirements/IssueTemplates.py
+++ b/src/RepoAuditor/Plugins/GitHubCustomization/Requirements/IssueTemplates.py
@@ -21,6 +21,9 @@ class IssueTemplates(ExistsRequirementImpl):
                 ".github/ISSUE_TEMPLATE.md",
                 "docs/ISSUE_TEMPLATE.md",
                 "ISSUE_TEMPLATE.md",
+                ".github/issue_template.md",
+                "docs/issue_template.md",
+                "issue_template.md",
                 # Directories
                 ".github/ISSUE_TEMPLATE",
             ],

--- a/src/RepoAuditor/Plugins/GitHubCustomization/Requirements/PullRequestTemplates.py
+++ b/src/RepoAuditor/Plugins/GitHubCustomization/Requirements/PullRequestTemplates.py
@@ -21,6 +21,9 @@ class PullRequestTemplate(ExistsRequirementImpl):
                 ".github/PULL_REQUEST_TEMPLATE.md",
                 "docs/PULL_REQUEST_TEMPLATE.md",
                 "PULL_REQUEST_TEMPLATE.md",
+                ".github/pull_request_template.md",
+                "docs/pull_request_template.md",
+                "pull_request_template.md",
                 # Directory with multiple templates
                 ".github/PULL_REQUEST_TEMPLATE",
             ],


### PR DESCRIPTION
## :pencil: Description
@mtanneau found a bug where because of Linux's filesystem being case sensitive, only checking for upper or lower case file names was leading to false negatives. E.g. checking for `PULL_REQUEST_TEMPLATE.md` would fail if the repository has `pull_request_template.md`.

This PR fixes this issue by checking both upper and lower case variants of the filename.

## :gear: Work Item
Please include link to the corresponding GitHub Issue or Project work item.

## :movie_camera: Demo
Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.
