### PR TITLE
Update Squash & Merge rationale

### DIFF
--- a/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardQueryRequirements/SquashCommitMerge.py
@@ -33,7 +33,8 @@ class SquashCommitMerge(StandardEnableRequirementImpl):
 
                 Reasons for this Default
                 ------------------------
-                - Rebase merging is not compatible with signed commits, as GitHub creates a new commit when squashing.
+                - When performing a Squash & Merge, GitHub creates a new merge commit with its key.
+                This makes it difficult to verify author signatures when looking at the commit history.
 
                 Reasons to Override this Default
                 --------------------------------


### PR DESCRIPTION
## :pencil: Description
Update the rationale for Squash & Merge to reflect the effect of GitHub signing a merge commit. Thanks @austin-weeks!

## :gear: Work Item
Fixes #43

## :movie_camera: Demo
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/47ec3673-e35c-4d4d-a3f5-324c670c18bf" />