### PR TITLE
Add `gitpython` to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 requires-python = ">= 3.10"
 dependencies = [
     "dbrownell-common>=0.14.10",
+    "gitpython>=3.1.44",
     "pluggy>=1.5.0",
     "requests>=2.32.3",
     "typer>=0.15.3",

--- a/uv.lock
+++ b/uv.lock
@@ -517,6 +517,7 @@ name = "repoauditor"
 source = { editable = "." }
 dependencies = [
     { name = "dbrownell-common" },
+    { name = "gitpython" },
     { name = "pluggy" },
     { name = "requests" },
     { name = "typer" },
@@ -537,6 +538,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dbrownell-common", specifier = ">=0.14.10" },
+    { name = "gitpython", specifier = ">=3.1.44" },
     { name = "pluggy", specifier = ">=1.5.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "typer", specifier = ">=0.15.3" },


### PR DESCRIPTION
## :pencil: Description
When installing `RepoAuditor` via `uv add RepoAuditor`, `gitpython` is not installed due to it missing from the `pyproject.toml` dependencies list.
This PR fixes that.

## :gear: Work Item
Reported by @austin-weeks 
