### PR TITLE
Use `poe` to generate coverage HTML file for easy viewing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Deactivate*.sh
 **/.coverage
 **/lcov.info
 **/.vscode
+**/coverage.xml
 
 build/**
 dist/**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -115,7 +115,26 @@ Please follow the steps below to complete the configuration.
 | Sign Artifacts | `uv run --with py-minisign python -c "import minisign; minisign.SecretKey.from_file(<temp_filename>).sign_file(<filename>, trusted_comment='<package_name> v<package_version>', drop_signature=True)` | Signs artifacts using [py-minisign](https://github.com/x13a/py-minisign). Note that the private key is stored as a [GitHub secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). | | :white_check_mark: |
 | Python Package Publishing | `uv publish` | Publish a python package to [PyPi](https://pypi.org/) using [uv](https://github.com/astral-sh/uv) based on settings in `pyproject.toml`. | | :white_check_mark: |
 
-### Contributing Changes
+### Viewing Test Coverage
+
+We use `pytest` with the `pytest-cov` plugin to generate code coverage reports of test cases.
+
+Running
+
+```shell
+uv run poe pytest-html
+```
+
+automatically generates an HTML version of the coverage report in a directory named `htmlcov`.
+To view these code coverage reports in your browser, and run
+
+```shell
+uv run python -m http.server --directory htmlcov
+```
+
+and go to the printed out URL.
+
+## Contributing Changes
 
 Pull requests are preferred, since they are specific. For more about how to create a pull request, see [this guide](https://help.github.com/articles/using-pull-requests/).
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ uvx RepoAuditor --include GitHub \
 
 The configuration (or config) file can make usage easier by recording preferences as well as facilitating sharing of enforced requirements within an organization.
 We have provided a sample configuration file called [default_config.yaml](https://github.com/gt-sse-center/RepoAuditor/blob/main/default_config.yaml), which can be used as:
+
 ```shell
 uvx run RepoAuditor --config default_config.yaml
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "autogitsemver>=0.8.0",
+    "poethepoet>=0.35.0",
     "pre-commit>=4.2.0",
     "pyfakefs>=5.8.0",
     "pytest>=8.3.5",
@@ -61,10 +62,13 @@ dev = [
 path = "src/RepoAuditor/__init__.py"
 
 [tool.pytest.ini_options]
-addopts = "--verbose -vv --capture=no --cov=RepoAuditor --cov-fail-under=95.0"
+addopts = "--verbose -vv --capture=no --cov=RepoAuditor --cov-fail-under=95.0 --cov-report term --cov-report xml:coverage.xml"
 python_files = [
     "**/*Test.py",
 ]
+
+[tool.poe.tasks]
+pytest-html = "uv run pytest --cov-report html"
 
 [tool.ruff]
 line-length = 110

--- a/uv.lock
+++ b/uv.lock
@@ -373,6 +373,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pastel"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/f1/4594f5e0fcddb6953e5b8fe00da8c317b8b41b547e2b3ae2da7512943c62/pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d", size = 7555, upload-time = "2020-09-16T19:21:12.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/18/a8444036c6dd65ba3624c63b734d3ba95ba63ace513078e1580590075d21/pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364", size = 5955, upload-time = "2020-09-16T19:21:11.409Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -388,6 +397,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "poethepoet"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pastel" },
+    { name = "pyyaml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/b1/d4f4361b278fae10f6074675385ce3acf53c647f8e6eeba22c652f8ba985/poethepoet-0.35.0.tar.gz", hash = "sha256:b396ae862d7626e680bbd0985b423acf71634ce93a32d8b5f38340f44f5fbc3e", size = 66006, upload-time = "2025-06-09T12:58:18.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/08/abc2d7e2400dd8906e3208f9b88ac610f097d7ee0c7a1fa4a157b49a9e86/poethepoet-0.35.0-py3-none-any.whl", hash = "sha256:bed5ae1fd63f179dfa67aabb93fa253d79695c69667c927d8b24ff378799ea75", size = 87164, upload-time = "2025-06-09T12:58:17.084Z" },
 ]
 
 [[package]]
@@ -527,6 +550,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "autogitsemver" },
+    { name = "poethepoet" },
     { name = "pre-commit" },
     { name = "pyfakefs" },
     { name = "pytest" },
@@ -548,6 +572,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "autogitsemver", specifier = ">=0.8.0" },
+    { name = "poethepoet", specifier = ">=0.35.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyfakefs", specifier = ">=5.8.0" },
     { name = "pytest", specifier = ">=8.3.5" },


### PR DESCRIPTION
## :pencil: Description
Added [poe]( https://github.com/nat-n/poethepoet) to add a command alias which automatically generates HTML coverage reports, and updated the `DEVELOPMENT.md` with instructions on how to take advantage of this.

## :gear: Work Item
Fix #154 

## :movie_camera: Demo
This is what the HTML report looks like, which is really easy to read and navigate.

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/e73a8062-fd36-48a5-95e4-d015513abe65" />

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/a8721319-ff9d-4229-927a-aadbd49acb7f" />
