### PR TITLE
Add support for `CODE_OF_CONDUCT.rst` file

### DIFF
--- a/src/RepoAuditor/Plugins/GitHubCommunityStandards/Requirements/CodeOfConduct.py
+++ b/src/RepoAuditor/Plugins/GitHubCommunityStandards/Requirements/CodeOfConduct.py
@@ -21,10 +21,13 @@ class CodeOfConduct(ExistsRequirementImpl):
             [
                 ".github/CODE_OF_CONDUCT",
                 ".github/CODE_OF_CONDUCT.md",
+                ".github/CODE_OF_CONDUCT.rst",
                 "docs/CODE_OF_CONDUCT",
                 "docs/CODE_OF_CONDUCT.md",
+                "docs/CODE_OF_CONDUCT.rst",
                 "CODE_OF_CONDUCT",
                 "CODE_OF_CONDUCT.md",
+                "CODE_OF_CONDUCT.rst",
             ],
             textwrap.dedent(
                 """\


### PR DESCRIPTION
## :pencil: Description
Include `.rst` extensions for the `CodeOfConduct` requirement.

## :gear: Work Item
Fixes #157 