### PR TITLE
Fix: GitHubCommunityStandards plugin includes PAT in repository URL when cloning

### DIFF
--- a/tests/Plugins/GitHubCommunityStandards/CommunityStandardsQuery_UnitTest.py
+++ b/tests/Plugins/GitHubCommunityStandards/CommunityStandardsQuery_UnitTest.py
@@ -15,11 +15,6 @@ from RepoAuditor.Plugins.GitHubCommunityStandards.CommunityStandardsQuery import
 )
 
 
-def mock_clone_from(github_url, repo_dirname, branch="main"):
-    """A mocked clone_from method for the git.Repo class."""
-    pass
-
-
 class MockTemporaryDirectory:
     """A mock class to replace tempfile.TemporaryDirectory."""
 
@@ -43,6 +38,11 @@ class TestCommunityStandardsQuery:
             "__init__",
             MockTemporaryDirectory.__init__,
         )
+
+        def mock_clone_from(github_url, repo_dirname, branch="main"):
+            """A mocked clone_from method for the git.Repo class."""
+            pass
+
         monkeypatch.setattr(
             Repo,
             "clone_from",
@@ -53,6 +53,68 @@ class TestCommunityStandardsQuery:
         query_data = query.GetData(module_data)
 
         assert query_data["repo_dir"].name == "test_temp_directory"
+
+    def test_GetData_adds_pat(self, module_data, monkeypatch):
+        """Test the GetData method adds PAT to URL"""
+        github_pat = "pat-123"
+        github_url = "https://github.com/owner/repo"
+        expected_url = "https://pat-123@github.com/owner/repo"
+        module_data["url"] = github_url
+        module_data["pat"] = github_pat
+
+        monkeypatch.setattr(
+            TemporaryDirectory,
+            "__init__",
+            MockTemporaryDirectory.__init__,
+        )
+
+        def mock_clone_from(github_url, repo_dirname, branch="main"):
+            assert github_url == expected_url
+
+        monkeypatch.setattr(Repo, "clone_from", mock_clone_from)
+
+        query = CommunityStandardsQuery()
+        _ = query.GetData(module_data)
+
+    def test_GetData_does_not_add_pat(self, module_data, monkeypatch):
+        """Test the GetData method preserves the URL when no PAT is provided"""
+        github_url = "https://github.com/owner/repo"
+        expected_url = "https://github.com/owner/repo"
+        module_data["url"] = github_url
+
+        monkeypatch.setattr(
+            TemporaryDirectory,
+            "__init__",
+            MockTemporaryDirectory.__init__,
+        )
+
+        def mock_clone_from(github_url, repo_dirname, branch="main"):
+            assert github_url == expected_url
+
+        monkeypatch.setattr(Repo, "clone_from", mock_clone_from)
+
+        query = CommunityStandardsQuery()
+        _ = query.GetData(module_data)
+
+    def test_GetData_handles_gitpython_errors(self, module_data, monkeypatch):
+        """Test the GetData method handles errors raised by the gitpyhon module"""
+        gitpython_error_msg = "error cloning repository"
+
+        monkeypatch.setattr(
+            TemporaryDirectory,
+            "__init__",
+            MockTemporaryDirectory.__init__,
+        )
+
+        def mock_clone_from(github_url, repo_dirname, branch="main"):
+            raise Exception(gitpython_error_msg)
+
+        monkeypatch.setattr(Repo, "clone_from", mock_clone_from)
+
+        query = CommunityStandardsQuery()
+        with pytest.raises(RuntimeError) as e_info:
+            _ = query.GetData(module_data)
+        assert gitpython_error_msg in str(e_info)
 
     def test_Cleanup(self, module_data):
         """Test the Cleanup method."""


### PR DESCRIPTION
## :pencil: Description
The GitHubCommunityStandards plugin now includes the provided PAT in the GitHub URL when cloning the target repository. This ensures the plugin works when auditing private repositories in an environment where the `git` cli is not authenticated with GitHub (such as within a GitHub Actions workflow).

Additionally, if an error occurs while attempting to clone the repository, a descriptive error message is now provided.

## :gear: Work Item
Fixes https://github.com/gt-sse-center/RepoAuditor/issues/165

## :movie_camera: Demo
Example descriptive error message:
<img width="872" height="185" alt="Screenshot 2025-07-10 at 2 41 58 PM" src="https://github.com/user-attachments/assets/f57abe4e-a093-40df-b95a-27a9e129c1f2" />

