### PR TITLE
Common test fixtures for end to end testing

### DIFF
--- a/tests/Plugins/CommunityStandards_EndToEndTest.py
+++ b/tests/Plugins/CommunityStandards_EndToEndTest.py
@@ -316,28 +316,3 @@ class TestCommunityStandards:
 
         assert result.exit_code == -1, result.output
         assert ScrubDurationGithuburlAndSpaces(result.stdout) == snapshot
-
-
-# ----------------------------------------------------------------------
-# ----------------------------------------------------------------------
-# ----------------------------------------------------------------------
-@pytest.fixture
-def args() -> list[str]:
-    return [
-        "--include",
-        "CommunityStandards",
-        "--CommunityStandards-url",
-        GetGithubUrl(),
-    ]
-
-
-# ----------------------------------------------------------------------
-@pytest.fixture
-def pat_args(args) -> list[str]:
-    _github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
-    CheckPATFileExists(_github_pat_filename)
-
-    with _github_pat_filename.open() as f:
-        pat_value = f.read().strip()
-
-    return args + ["--CommunityStandards-pat", pat_value]

--- a/tests/Plugins/GitHub_EndToEndTest.py
+++ b/tests/Plugins/GitHub_EndToEndTest.py
@@ -7,14 +7,11 @@
 """End-to-end tests for the GitHub plugin"""
 
 import os
-from pathlib import Path
 
 import pytest
-from dbrownell_Common.TestHelpers.StreamTestHelpers import (
-    InitializeStreamCapabilities,
-)
+from dbrownell_Common.TestHelpers.StreamTestHelpers import InitializeStreamCapabilities
 from typer.testing import CliRunner
-from utilities import CheckPATFileExists, GetGithubUrl, ScrubDurationGithuburlAndSpaces
+from utilities import ScrubDurationGithuburlAndSpaces
 
 from RepoAuditor.EntryPoint import app
 
@@ -392,28 +389,3 @@ class TestRulesets:
 
         assert result.exit_code == -1, result.output
         assert ScrubDurationGithuburlAndSpaces(result.stdout) == snapshot
-
-
-# ----------------------------------------------------------------------
-# ----------------------------------------------------------------------
-# ----------------------------------------------------------------------
-@pytest.fixture
-def args() -> list[str]:
-    return [
-        "--include",
-        "GitHub",
-        "--GitHub-url",
-        GetGithubUrl(),
-    ]
-
-
-# ----------------------------------------------------------------------
-@pytest.fixture
-def pat_args(args) -> list[str]:
-    _github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
-    CheckPATFileExists(_github_pat_filename)
-
-    with _github_pat_filename.open() as f:
-        pat_value = f.read().strip()
-
-    return args + ["--GitHub-pat", pat_value]

--- a/tests/Plugins/conftest.py
+++ b/tests/Plugins/conftest.py
@@ -4,17 +4,59 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Common test fixtures for Plugins"""
+"""Common test fixtures for Plugins."""
+
+from typing import Any
+from pathlib import Path
 
 import pytest
-from GitHubModule.fixtures import session
+
+# `session` included here so it is available for all tests
+from GitHubModule.fixtures import session  # noqa: F401
+from utilities import CheckPATFileExists, GetGithubUrl
 
 from RepoAuditor.Plugins.GitHubBase.Module import _GitHubSession
 
 
 @pytest.fixture
-def module_data():
+def module_data() -> dict[str, Any]:
+    """Get the data required by the module."""
     return {
         "session": _GitHubSession("https://github.com/gt-sse-center/RepoAuditor", "pat"),
         "url": "https://github.com/gt-sse-center/RepoAuditor",
     }
+
+
+# ----------------------------------------------------------------------
+@pytest.fixture
+def args(request) -> list[str]:
+    """Fixture for the command line arguments.
+    `request` is a fixture representing the object
+    which is requesting this fixture.
+    """
+    # Get the plugin name from the requesting test.
+    plugin_name = request.module.__name__.split("_")[0]
+    return [
+        "--include",
+        plugin_name,
+        f"--{plugin_name}-url",
+        GetGithubUrl(),
+    ]
+
+
+# ----------------------------------------------------------------------
+@pytest.fixture
+def pat_args(request, args: list[str]) -> list[str]:
+    """Fixture for the PAT along with the command line arguments.
+
+    `request` is a fixture representing the object
+    which is requesting this fixture.
+    """
+    _github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
+    CheckPATFileExists(_github_pat_filename)
+
+    with _github_pat_filename.open() as f:
+        pat_value = f.read().strip()
+
+    plugin_name = request.module.__name__.split("_")[0]
+    return [*args, f"--{plugin_name}-pat", pat_value]

--- a/tests/Plugins/utilities.py
+++ b/tests/Plugins/utilities.py
@@ -35,14 +35,15 @@ def ScrubSpaces(content: str) -> str:
 # ----------------------------------------------------------------------
 def ScrubGithubUrl(content: str) -> str:
     """
-    Function to replace the GitHub username and (possibly) alternative repository name with the default one.
+    Function to replace the GitHub username and (possibly)
+    alternative repository name with a scrubbed value.
     """
 
     def replace_func(_: Match) -> str:
         return "'<scrubbed-github-url>'"
 
     return re.sub(
-        r"('https?:\/\/.+')",
+        r"('https?:\/\/.+?')",
         replace_func,
         content,
     )


### PR DESCRIPTION
## :pencil: Description
Move test fixtures to common `conftest.py` file so we avoid duplication.

## :gear: Work Item
Good housekeeping. We now have a common place to put fixtures used across test modules leading to cleaner code.
