### PR TITLE
Provide fixture names and add docstrings for tests

### DIFF
--- a/tests/Plugins/CommunityStandards/CommunityStandardsQuery_UnitTest.py
+++ b/tests/Plugins/CommunityStandards/CommunityStandardsQuery_UnitTest.py
@@ -27,10 +27,15 @@ class MockTemporaryDirectory:
 
 @pytest.fixture(autouse=True)
 def patch_temp_directory(monkeypatch):
+    """Prevent creation of TemporaryDirectory within GetData calls,
+    so we don't need to perform cleanup.
+    """
     monkeypatch.delattr("tempfile.TemporaryDirectory")
 
 
 class TestCommunityStandardsQuery:
+    """Tests for CommunityStandardsQuery class."""
+
     def test_GetData(self, module_data, monkeypatch):
         """Test the GetData method."""
         monkeypatch.setattr(
@@ -41,7 +46,6 @@ class TestCommunityStandardsQuery:
 
         def mock_clone_from(github_url, repo_dirname, branch="main"):
             """A mocked clone_from method for the git.Repo class."""
-            pass
 
         monkeypatch.setattr(
             Repo,

--- a/tests/Plugins/CommunityStandards_EndToEndTest.py
+++ b/tests/Plugins/CommunityStandards_EndToEndTest.py
@@ -321,8 +321,8 @@ class TestCommunityStandards:
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
-@pytest.fixture
-def args() -> list[str]:
+@pytest.fixture(name="args")
+def args_fixture() -> list[str]:
     return [
         "--include",
         "CommunityStandards",
@@ -332,8 +332,8 @@ def args() -> list[str]:
 
 
 # ----------------------------------------------------------------------
-@pytest.fixture
-def pat_args(args) -> list[str]:
+@pytest.fixture(name="pat_args")
+def pat_args_fixture(args) -> list[str]:
     github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
     CheckPATFileExists(github_pat_filename)
 

--- a/tests/Plugins/GitHubEnterprise_EndToEndTest.py
+++ b/tests/Plugins/GitHubEnterprise_EndToEndTest.py
@@ -23,8 +23,8 @@ pytest.fixture(InitializeStreamCapabilities(), scope="session", autouse=True)
 
 
 # ----------------------------------------------------------------------
-@pytest.fixture
-def args() -> list[str]:
+@pytest.fixture(name="args")
+def args_fixture() -> list[str]:
     return [
         "--include",
         "GitHub",
@@ -37,8 +37,8 @@ def args() -> list[str]:
 
 
 # ----------------------------------------------------------------------
-@pytest.fixture
-def pat_args(args) -> list[str]:
+@pytest.fixture(name="pat_args")
+def pat_args_fixture(args) -> list[str]:
     github_pat_filename = (Path(__file__).parent / "github_gatech_pat.txt").resolve()
     parsed = urllib.parse.urlparse(GetGithubUrl("enterprise"))
     parsed = parsed._replace(path="")

--- a/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/DismissStalePullRequestApprovals_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.DismissStale
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "branch": "main",
@@ -27,12 +27,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return DismissStalePullRequestApprovals()
 
 
 class TestDismissStalePullRequestApprovals:
+    """Tests for the DismissStalePullRequestApprovals requirement class."""
+
     def test_required_pull_request_reviews_missing(self, requirement, query_data):
         """Test when `required_pull_request_reviews` is missing."""
         query_data["branch_protection_data"] = {}

--- a/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/EnsureStatusChecks_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/EnsureStatusChecks_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.EnsureStatus
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "branch": "main",
@@ -27,12 +27,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return EnsureStatusChecks()
 
 
 class TestEnsureStatusChecks:
+    """Tests for the EnsureStatusChecks requirement class."""
+
     def test_disabled(self, requirement, query_data):
         """Test disabled requirement"""
         requirement_args = {"disabled": True}

--- a/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireApprovalMostRecentPush_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireAppro
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "branch": "main",
@@ -27,12 +27,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return RequireApprovalMostRecentPush()
 
 
 class TestRequireApprovalMostRecentPush:
+    """Tests for the RequireApprovalMostRecentPush requirement class."""
+
     def test_required_pull_request_reviews_missing(self, requirement, query_data):
         """Test when `required_pull_request_reviews` is missing"""
         query_data["branch_protection_data"] = {}

--- a/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireApprovals_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireApprovals_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireAppro
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "branch": "main",
@@ -25,12 +25,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return RequireApprovals()
 
 
 class TestRequireApprovals:
+    """Tests for the RequireApprovals requirement class."""
+
     def test_required_pull_request_reviews_missing(self, requirement, query_data):
         """Test when `required_pull_request_reviews` is missing"""
         query_data["branch_protection_data"] = {}

--- a/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireCodeOwnerReview_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireCodeOwnerReview_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireCodeO
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "branch": "main",
@@ -27,12 +27,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return RequireCodeOwnerReview()
 
 
 class TestRequireCodeOwnerReview:
+    """Tests for the RequireCodeOwnerReview requirement class."""
+
     def test_required_pull_request_reviews_missing(self, requirement, query_data):
         """Test when `required_pull_request_reviews` is missing"""
         query_data["branch_protection_data"] = {}

--- a/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireUpToDateBranches_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ClassicBranchProtectionRequirements/RequireUpToDateBranches_UnitTest.py
@@ -1,3 +1,11 @@
+# -------------------------------------------------------------------------------
+# |
+# |  Copyright (c) 2024 Scientific Software Engineering Center at Georgia Tech
+# |  Distributed under the MIT License.
+# |
+# -------------------------------------------------------------------------------
+"""Unit tests for RequireUpToDateBranches."""
+
 import pytest
 
 from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireUpToDateBranches import (
@@ -6,8 +14,9 @@ from RepoAuditor.Plugins.GitHub.ClassicBranchProtectionRequirements.RequireUpToD
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
+    """Sample query data fixture."""
     return {
         "session": session,
         "branch": "main",
@@ -19,12 +28,15 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
+    """RequireUpToDateBranches requirement fixture."""
     return RequireUpToDateBranches()
 
 
 class TestRequireUpToDateBranches:
+    """Tests for RequireUpToDateBranches requirement."""
+
     def test_required_status_checks_missing(self, requirement, query_data):
         """Test when `required_status_checks` is missing"""
         query_data["branch_protection_data"] = {}

--- a/tests/Plugins/GitHubModule/DefaultBranchQueryRequirements/Protected_UnitTest.py
+++ b/tests/Plugins/GitHubModule/DefaultBranchQueryRequirements/Protected_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.DefaultBranchRequirements.Protected import Prote
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "default_branch_data": {
@@ -22,12 +22,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return Protected()
 
 
 class TestProtected:
+    """Tests for the Protected requirement class."""
+
     def test_Incomplete(self, requirement, query_data):
         """Test for incomplete result"""
         query_data["default_branch_data"] = {}

--- a/tests/Plugins/GitHubModule/GitHubSession_UnitTest.py
+++ b/tests/Plugins/GitHubModule/GitHubSession_UnitTest.py
@@ -14,8 +14,8 @@ import requests
 from RepoAuditor.Plugins.GitHubBase.Module import _GitHubSession
 
 
-@pytest.fixture
-def github_pat(fs):
+@pytest.fixture(name="github_pat")
+def github_pat_fixture(fs):
     """Fixture for GitHub PAT file, which creates a fake PAT file and returns the path."""
     pat_path = Path(__file__).parent / "dummy_github_pat.txt"
     fs.create_file(pat_path, contents="github_path_abcdefghijklmnop")

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/DependabotSecurityUpdates_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/DependabotSecurityUpdates_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.DependabotSecurityUpdates i
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -28,12 +28,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return DependabotSecurityUpdates()
 
 
 class TestDependabotSecurityUpdates:
+    """Tests for the DependabotSecurityUpdates requirement class."""
+
     def test_security_and_analysis_missing(self, requirement, query_data):
         """Test if `security_and_analysis` is missing"""
         query_data["standard"] = {}

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/Description_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/Description_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.Description import Descript
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -22,13 +22,13 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return Description()
 
 
 class TestDescription:
-    """Unit tests for the Description requirement."""
+    """Tests for the Description requirement class."""
 
     def test_description_missing(self, requirement, query_data):
         """Test if `description` is missing.

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/License_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/License_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.License import License
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -24,12 +24,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return License()
 
 
 class TestLicense:
+    """Tests for the License requirement class."""
+
     def test_license_missing(self, requirement, query_data):
         """Check if no "license" key in query_data
         We should get a `IncompleteDataResult`.

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/MergeCommitMessage_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/MergeCommitMessage_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.MergeCommitMessage import M
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -23,12 +23,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return MergeCommitMessage()
 
 
 class TestMergeCommitMessage:
+    """Tests for the MergeCommitMessage requirement class."""
+
     def test_allow_merge_commit_missing(self, requirement, query_data):
         """Test if `allow_merge_commit` is missing"""
         query_data["standard"] = {}

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/Private_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/Private_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.Private import Private
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -22,12 +22,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return Private()
 
 
 class TestPrivate:
+    """Tests for the Private requirement class."""
+
     def test_private_missing(self, requirement, query_data):
         """Test if `private` is missing"""
         query_data["standard"] = {}

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/SecretScanningPushProtection_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/SecretScanningPushProtection_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.SecretScanningPushProtectio
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -28,12 +28,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return SecretScanningPushProtection()
 
 
 class TestSecretScanningPushProtection:
+    """Tests for the SecretScanningPushProtection requirement class."""
+
     def test_security_and_analysis_missing(self, requirement, query_data):
         """Test if `security_and_analysis` is missing"""
         query_data["standard"] = {}

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/SecretScanning_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/SecretScanning_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.SecretScanning import Secre
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -26,12 +26,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return SecretScanning()
 
 
 class TestSecretScanning:
+    """Tests for the SecretScanning requirement class."""
+
     def test_security_and_analysis_missing(self, requirement, query_data):
         # Test if `security_and_analysis` is missing
         query_data["standard"] = {}

--- a/tests/Plugins/GitHubModule/StandardQueryRequirements/SquashMergeCommitMessage_UnitTest.py
+++ b/tests/Plugins/GitHubModule/StandardQueryRequirements/SquashMergeCommitMessage_UnitTest.py
@@ -14,8 +14,8 @@ from RepoAuditor.Plugins.GitHub.StandardRequirements.SquashMergeCommitMessage im
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def query_data(session):
+@pytest.fixture(name="query_data")
+def query_data_fixture(session):
     return {
         "session": session,
         "standard": {
@@ -25,12 +25,14 @@ def query_data(session):
     }
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return SquashMergeCommitMessage()
 
 
 class TestSquashMergeCommitMessage:
+    """Tests for the SquashMergeCommitMessage requirement class."""
+
     def test_allow_merge_commit_missing(self, requirement, query_data):
         """Test if `allow_merge_commit` is missing"""
         query_data["standard"] = {}

--- a/tests/Plugins/GitHubModule/ValueRequrementImpl_UnitTest.py
+++ b/tests/Plugins/GitHubModule/ValueRequrementImpl_UnitTest.py
@@ -12,8 +12,8 @@ from RepoAuditor.Plugins.GitHub.Impl.ValueRequirementImpl import DoesNotApplyRes
 from RepoAuditor.Requirement import EvaluateResult
 
 
-@pytest.fixture
-def requirement():
+@pytest.fixture(name="requirement")
+def requirement_fixture():
     return ValueRequirementImpl(
         "TestValueRequirement",
         "42",
@@ -24,8 +24,8 @@ def requirement():
     )
 
 
-@pytest.fixture
-def requirement_does_not_apply_result():
+@pytest.fixture(name="requirement_does_not_apply_result")
+def requirement_does_not_apply_result_fixture():
     return ValueRequirementImpl(
         "TestValueRequirement",
         "42",

--- a/tests/Plugins/GitHubModule/fixtures.py
+++ b/tests/Plugins/GitHubModule/fixtures.py
@@ -7,17 +7,22 @@
 """Common fixtures for GitHubModule unit tests."""
 
 import pytest
+from dataclasses import dataclass
 
 
 @pytest.fixture
 def session():
     """Create a dummy GitHub API session object."""
 
+    @dataclass(frozen=True)
     class _GithubSession_:
-        pass
+        github_url: str
+        pat: str
+        is_enterprise: bool
 
-    s = _GithubSession_()
-    s.github_url = "https://github.com/gt-sse-center/RepoAuditor"
-    s.pat = "github_pat_dummy"
-    s.is_enterprise = False
+    s = _GithubSession_(
+        "https://github.com/gt-sse-center/RepoAuditor",
+        pat="github_pat_dummy",
+        is_enterprise=False,
+    )
     return s

--- a/tests/Plugins/GitHub_EndToEndTest.py
+++ b/tests/Plugins/GitHub_EndToEndTest.py
@@ -456,8 +456,8 @@ class TestRulesets:
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
 # ----------------------------------------------------------------------
-@pytest.fixture
-def args() -> list[str]:
+@pytest.fixture(name="args")
+def args_fixture() -> list[str]:
     """Common arguments for GitHub plugin and corresponding URL."""
     return [
         "--include",
@@ -468,8 +468,8 @@ def args() -> list[str]:
 
 
 # ----------------------------------------------------------------------
-@pytest.fixture
-def pat_args(args) -> list[str]:
+@pytest.fixture(name="pat_args")
+def pat_args_fixture(args) -> list[str]:
     github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
     CheckPATFileExists(github_pat_filename)
 


### PR DESCRIPTION
## :pencil: Description
The python linter complains about overriding variables from an outer scope. As per `pytest`, specifying the fixture name is the correct way to fix this.

Also added some docstrings for tests.

## :gear: Work Item
Housekeeping.
