### PR TITLE
Set version in development to 0.0.0

### DIFF
--- a/src/RepoAuditor/__init__.py
+++ b/src/RepoAuditor/__init__.py
@@ -2,4 +2,4 @@ APP_NAME = "RepoAuditor"
 
 # Note that the default value below will be used until the value
 # here is explicitly updated by the Continuous Integration system.
-__version__ = "0.1.0"
+__version__ = "0.0.0"


### PR DESCRIPTION
## :pencil: Description
To be able to disambiguate between a release version of `RepoAuditor` and a dev version, this PR sets the version number in the dev version to `0.0.0`.

## :gear: Work Item
Fixes #163 
