### PR TITLE
Update rationale for `MergeCommitMessage` and `SquashMergeCommitMessage`

### DIFF
--- a/src/RepoAuditor/Plugins/GitHub/StandardRequirements/MergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardRequirements/MergeCommitMessage.py
@@ -30,18 +30,18 @@ class MergeCommitMessage(StandardValueRequirementImpl):
             _GetValue,
             textwrap.dedent(
                 """\
-                Available values:
+                Available values on GitHub:
 
-                PR_TITLE [Default message]
+                Default message [PR_TITLE]
                     Pull Request number and head branch on the first line; pull request title on the third line
 
-                BLANK [Default to pull request title]
+                Default to pull request title [BLANK]
                     Pull Request title and number on the first line.
 
-                PR_BODY [Default to pull request title and description]
+                Default to pull request title and description [PR_BODY]
                     Pull Request title and number on the first line; pull request description starting on the third line.
 
-            The default setting is BLANK.
+            The default setting is "Default to pull request title [BLANK]".
 
             Reasons for this Default
             ------------------------

--- a/src/RepoAuditor/Plugins/GitHub/StandardRequirements/SquashMergeCommitMessage.py
+++ b/src/RepoAuditor/Plugins/GitHub/StandardRequirements/SquashMergeCommitMessage.py
@@ -30,20 +30,20 @@ class SquashMergeCommitMessage(StandardValueRequirementImpl):
             _GetValue,
             textwrap.dedent(
                 """\
-                Available values:
+                Available values on GitHub:
 
-                BLANK [Default to pull request title]
+                Default to pull request title [BLANK]
                     Pull Request title and number on the first line.
 
-                COMMIT_MESSAGES [Default to pull request title and commit details]
+                Default to pull request title and commit details [COMMIT_MESSAGES]
                     Commit title and...
                         [Single Commit] ...commit message
                         [Multiple Commits] ...pull request title and number and list of commits
 
-                PR_BODY [Default to pull request title and description]
+                Default to pull request title and description [PR_BODY]
                     Pull Request title and number on the first line; commit description starting on the third line.
 
-            The default setting is COMMIT_MESSAGES.
+            The default setting is "Default to pull request title and commit details [COMMIT_MESSAGES]".
 
             Reasons for this Default
             ------------------------


### PR DESCRIPTION
## :pencil: Description
Update the rationales on `MergeCommitMessage` and `SquashMergeCommitMessage` to make it easier for the user to understand.

## :gear: Work Item
Fixes #191 and #192
