### PR TITLE
Fix CommunityStandards flag in default config

### DIFF
--- a/default_config.yaml
+++ b/default_config.yaml
@@ -1,4 +1,4 @@
-includes: ["GitHub", "GitHubCommunityStandards"]
+includes: ["GitHub", "CommunityStandards"]
 GitHub-url: "https://github.com/gt-sse-center/RepoAuditor"
-GitHubCommunityStandards-url: "https://github.com/gt-sse-center/RepoAuditor"
+CommunityStandards-url: "https://github.com/gt-sse-center/RepoAuditor"
 # GitHub-pat: "PAT"


### PR DESCRIPTION
## :pencil: Description

Replaces `GitHubCommunityStandard` with `CommunityStandards` in `default_config.yaml`

## :gear: Work Item

#209 

## :movie_camera: Demo

No more error :)

<img width="1829" height="759" alt="image" src="https://github.com/user-attachments/assets/cdc8779e-63f2-4656-9915-a4dcc7994547" />

