### PR TITLE
Don't read PAT in tests

### DIFF
--- a/tests/Plugins/CommunityStandards_EndToEndTest.py
+++ b/tests/Plugins/CommunityStandards_EndToEndTest.py
@@ -334,10 +334,7 @@ def args() -> list[str]:
 # ----------------------------------------------------------------------
 @pytest.fixture
 def pat_args(args) -> list[str]:
-    _github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
-    CheckPATFileExists(_github_pat_filename)
+    github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
+    CheckPATFileExists(github_pat_filename)
 
-    with _github_pat_filename.open() as f:
-        pat_value = f.read().strip()
-
-    return args + ["--CommunityStandards-pat", pat_value]
+    return args + ["--CommunityStandards-pat", str(github_pat_filename)]

--- a/tests/Plugins/GitHubEnterprise_EndToEndTest.py
+++ b/tests/Plugins/GitHubEnterprise_EndToEndTest.py
@@ -39,15 +39,12 @@ def args() -> list[str]:
 # ----------------------------------------------------------------------
 @pytest.fixture
 def pat_args(args) -> list[str]:
-    _github_pat_filename = (Path(__file__).parent / "github_gatech_pat.txt").resolve()
+    github_pat_filename = (Path(__file__).parent / "github_gatech_pat.txt").resolve()
     parsed = urllib.parse.urlparse(GetGithubUrl("enterprise"))
     parsed = parsed._replace(path="")
-    CheckPATFileExists(_github_pat_filename, github_url=parsed.geturl())
+    CheckPATFileExists(github_pat_filename, github_url=parsed.geturl())
 
-    with _github_pat_filename.open() as f:
-        pat_value = f.read().strip()
-
-    return args + ["--GitHub-pat", pat_value]
+    return args + ["--GitHub-pat", str(github_pat_filename)]
 
 
 # ----------------------------------------------------------------------

--- a/tests/Plugins/GitHubModule/fixtures.py
+++ b/tests/Plugins/GitHubModule/fixtures.py
@@ -18,6 +18,6 @@ def session():
 
     s = _GithubSession_()
     s.github_url = "https://github.com/gt-sse-center/RepoAuditor"
-    s.pat = "dummy_github_pat.txt"
+    s.pat = "github_pat_dummy"
     s.is_enterprise = False
     return s

--- a/tests/Plugins/GitHub_EndToEndTest.py
+++ b/tests/Plugins/GitHub_EndToEndTest.py
@@ -470,10 +470,7 @@ def args() -> list[str]:
 # ----------------------------------------------------------------------
 @pytest.fixture
 def pat_args(args) -> list[str]:
-    _github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
-    CheckPATFileExists(_github_pat_filename)
+    github_pat_filename = (Path(__file__).parent / "github_pat.txt").resolve()
+    CheckPATFileExists(github_pat_filename)
 
-    with _github_pat_filename.open() as f:
-        pat_value = f.read().strip()
-
-    return args + ["--GitHub-pat", pat_value]
+    return args + ["--GitHub-pat", str(github_pat_filename)]


### PR DESCRIPTION
## :pencil: Description
This PR updates the `pat_args` test fixture to pass in the PAT file directly and leave the reading of the PAT file to the `GitHubBaseModule` class.

I also refactored the `GitHubBaseModule` class a bit to decouple the PAT reading logic from the `GitHubSession` class since the latter is mocked in some tests.

## :gear: Work Item
Fixes #214 

## :movie_camera: Demo
PAT is no longer revealed in plaintext.

<img width="1555" height="417" alt="image" src="https://github.com/user-attachments/assets/c0841cb2-76a0-4a4d-9b81-563c47364b08" />
