### PR TITLE
Small Fixes

### DIFF
--- a/src/RepoAuditor/Plugins/CommunityStandards/Requirements/LicenseFile.py
+++ b/src/RepoAuditor/Plugins/CommunityStandards/Requirements/LicenseFile.py
@@ -14,7 +14,7 @@ from RepoAuditor.Plugins.CommunityStandards.Impl.ExistsRequirementImpl import (
 
 
 class LicenseFile(ExistsRequirementImpl):
-    """Validates that a CODE_OF_CONDUCT file is configured."""
+    """Validates that a file with licensing information is present."""
 
     def __init__(self) -> None:
         super().__init__(

--- a/tests/Plugins/CommunityStandards/CommunityStandards_UnitTest.py
+++ b/tests/Plugins/CommunityStandards/CommunityStandards_UnitTest.py
@@ -4,7 +4,7 @@
 # |  Distributed under the MIT License.
 # |
 # -------------------------------------------------------------------------------
-"""Unit tests for the GitHub Community Standards Plugin"""
+"""Unit tests for the Community Standards Plugin"""
 
 import sys
 from pathlib import Path


### PR DESCRIPTION
## :pencil: Description
Fixed a docstring and a filename in the `CommunityStandards` plugin/test.

Also bump the minor version.

