### PR TITLE
Update docs

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -146,7 +146,7 @@ We use [MkDocs](https://www.mkdocs.org/) to generate the documentation website.
 To generate the docs, please run
 
 ```sh
-uv run mkdocs --serve
+uv run mkdocs serve
 ```
 
 and go to the specified URL.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@
 
 It helps maintain high-quality and consistent open-source repositories even if you are new to maintaining open-source software.
 
+## Compatibility
+
+We only support Python 3.10 and above. Please make sure you have a suitable python version.
+
 ## Contents
 
 - [Installation](#installation)
@@ -16,10 +20,13 @@ It helps maintain high-quality and consistent open-source repositories even if y
 ## Installation
 
 We recommend using [uv](https://docs.astral.sh/uv/#uv) since it can install `RepoAuditor` as a tool via `uvx` into a sandbox environment for quick use.
-This lets you directly run `RepoAuditor`.
 
+This lets you directly run `RepoAuditor` without the need to clone the repository or install the package.
+
+<!-- termynal -->
 ```sh
-uvx RepoAuditor
+> uvx RepoAuditor --version
+RepoAuditor v0.4.2
 ```
 
 Alternatively, you can install `RepoAuditor` via `uv` or `pip`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ theme:
     primary: teal
     accent: lime
 
+plugins:
+  - termynal
 
 # Extensions to render emojis
 markdown_extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "ruff>=0.11.8",
     "syrupy>=4.9.1",
     "mkdocs-material>=9.6.16",
+    "termynal>=0.13.1",
 ]
 
 [tool.hatch.version]

--- a/uv.lock
+++ b/uv.lock
@@ -781,6 +781,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "syrupy" },
+    { name = "termynal" },
 ]
 
 [package.metadata]
@@ -803,6 +804,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.8" },
     { name = "syrupy", specifier = ">=4.9.1" },
+    { name = "termynal", specifier = ">=0.13.1" },
 ]
 
 [[package]]
@@ -1013,6 +1015,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/f8/022d8704a3314f3e96dbd6bbd16ebe119ce30e35f41aabfa92345652fceb/syrupy-4.9.1.tar.gz", hash = "sha256:b7d0fcadad80a7d2f6c4c71917918e8ebe2483e8c703dfc8d49cdbb01081f9a4", size = 52492, upload-time = "2025-03-24T01:36:37.225Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/9d/aef9ec5fd5a4ee2f6a96032c4eda5888c5c7cec65cef6b28c4fc37671d88/syrupy-4.9.1-py3-none-any.whl", hash = "sha256:b94cc12ed0e5e75b448255430af642516842a2374a46936dd2650cfb6dd20eda", size = 52214, upload-time = "2025-03-24T01:36:35.278Z" },
+]
+
+[[package]]
+name = "termynal"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/a6/099ed030e3e534ec91aec84dfe2cb11cea6ec8dcbec454fe569cdbbb4888/termynal-0.13.1.tar.gz", hash = "sha256:c7abecfdbda3ccdeee2723049a70f0e2e7f63e1973bb9b8f0b3fe6c1bfb391cd", size = 174253, upload-time = "2025-09-01T13:03:35.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/72/6949a512f16653cecebb737b8512ee76ca078d8e0e4e948d7322b528fb4d/termynal-0.13.1-py3-none-any.whl", hash = "sha256:7a1605a4d4ed38bf851bf25f842aafa52ef29786d52762aecee59622ed030592", size = 10628, upload-time = "2025-09-01T13:03:34.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## :pencil: Description
Update docs to inform users that we only support Python 3.10+. `uvx` unfortunately doesn't seem to do that currently.

I also added the `termynal` package so we can animate commands in the docs similar to `typer`.

## :gear: Work Item
#246 
